### PR TITLE
[WIP] Improve validation error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Return specific validation errors for `oneOf`, by using `statementType` to pick the correct sub-schema. Only works for BODS. [#16](https://github.com/openownership/cove-bods/issues/16)
 
+### Changed
+
+- Reword and add some HTML tags to validation error messages, for BODS [#16](https://github.com/openownership/cove-bods/issues/16#issuecomment-465055911)
+
 ## [0.4.0] - 2019-03-14
 
 ### Changed


### PR DESCRIPTION
https://github.com/openownership/cove-bods/issues/16

Return specific validation errors for `oneOf`, by using `statementType` to pick the correct sub-schema. Only works for BODS.

Because the change is BODS specific, tests are currently only in the lib-cove-bods repo - https://github.com/openownership/lib-cove-bods/pull/5

Here's what this looks like in the web interface https://github.com/openownership/cove-bods/issues/16#issuecomment-460512901