### PR TITLE
Put more data into the error JSON returned, when grouping validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 __pycache__
 /libcove/lib/org-ids.json
 /libcove/lib/org-ids.json.lock
+/libcove.egg-info
+*~
+*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Put more data into the error JSON returned, when grouping validation errors. This will allow different CoVEs to write their own validation messages.
+
 ## [0.5.0] - 2019-03-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Put more data into the error JSON returned, when grouping validation errors. This will allow different CoVEs to write their own validation messages.
+- Put more data into the error JSON returned, when grouping validation errors. This will allow different CoVEs to write their own validation messages. [#14](https://github.com/OpenDataServices/lib-cove/pull/14)
 
 ## [0.5.0] - 2019-03-25
 
 ### Added
 
-- Return specific validation errors for `oneOf`, by using `statementType` to pick the correct sub-schema. Only works for BODS. [#16](https://github.com/openownership/cove-bods/issues/16)
+- Return specific validation errors for `oneOf`, by using `statementType` to pick the correct sub-schema. Only works for BODS. [cove-bods#16](https://github.com/openownership/cove-bods/issues/16)
 
 ## [0.4.0] - 2019-03-14
 

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -8,7 +8,6 @@ import re
 import collections
 import datetime
 import fcntl
-from collections import OrderedDict
 
 from cached_property import cached_property
 from .tools import cached_get_request, decimal_default

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -519,8 +519,11 @@ def get_schema_validation_errors(json_data, schema_obj, schema_name, cell_src_ma
                 value["sheet"], value["row_number"] = first_reference
 
         header = value.get('header')
+        header_extra = None
         if not header and len(e.path):
             header = e.path[-1]
+            if isinstance(e.path[-1], int) and len(e.path) >= 2:
+                header_extra = '{}/{}'.format(e.path[-2], e.path[-1])
 
         null_clause = ''
         validator_type = e.validator
@@ -562,6 +565,7 @@ def get_schema_validation_errors(json_data, schema_obj, schema_name, cell_src_ma
             if heading:
                 field_name = heading[0][1]
                 value['header'] = heading[0][1]
+            header = field_name
             if parent_name:
                 message = "'{}' is missing but required within '{}'".format(field_name, parent_name)
                 message_safe = format_html("<code>{}</code> is missing but required within <code>{}</code>", field_name, parent_name) # noqa
@@ -587,6 +591,9 @@ def get_schema_validation_errors(json_data, schema_obj, schema_name, cell_src_ma
         if message_safe is None:
             message_safe = escape(message)
 
+        if header_extra is None:
+            header_extra = header
+
         unique_validator_key = OrderedDict([
             ('message', message),
             ('message_safe', conditional_escape(message_safe)),
@@ -597,9 +604,8 @@ def get_schema_validation_errors(json_data, schema_obj, schema_name, cell_src_ma
             ('validator_value', e.validator_value if e.validator not in ['enum', 'required'] else None),
             ('message_type', validator_type),
             ('path_no_number', path_no_number),
-            # Don't pass 'header' if it is a number, as this will mean less
-            # grouping, which we don't want.
-            ('header', header if isinstance(header, str) else None),
+            ('header', header),
+            ('header_extra', header_extra),
             ('null_clause', null_clause),
         ])
         validation_errors[json.dumps(unique_validator_key)].append(value)


### PR DESCRIPTION
This will allow different CoVEs to write their own validation messages. We want this for BODS first of all.

Context: https://github.com/openownership/cove-bods/issues/16#issuecomment-478426310