### PR TITLE
add root_id as an optional parameter to convert_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Allow the passing of `root_id` to the conversion tool
+- Revert the changes made in v0.9.0
 
 ## [0.9.0] - 2019-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Revert the changes made in v0.9.0
+- Allow the passing of `root_id` to the conversion tool
 
 ## [0.9.0] - 2019-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.10.0] - 2019-09-06
+
+### Changed
+
+- Allow the passing of `root_id` to the conversion tool
+
 ## [0.9.0] - 2019-08-29
 
 ### Changed

--- a/libcove/lib/converters.py
+++ b/libcove/lib/converters.py
@@ -118,7 +118,7 @@ def convert_spreadsheet(upload_dir, upload_url, file_name, file_type, lib_cove_c
     return context
 
 
-def convert_json(upload_dir, upload_url, file_name, lib_cove_config, root_list_path=None,
+def convert_json(upload_dir, upload_url, file_name, lib_cove_config, root_list_path=None, root_id=None,
                  schema_url=None, replace=False, request=None, flatten=False, cache=True, xml=False):
     context = {}
     converted_path = os.path.join(upload_dir, 'flattened')
@@ -126,11 +126,14 @@ def convert_json(upload_dir, upload_url, file_name, lib_cove_config, root_list_p
     if root_list_path is None:
         root_list_path = lib_cove_config.config['root_list_path']
 
+    if root_id is None:
+        root_id = lib_cove_config.config['root_id']
+
     flatten_kwargs = dict(
         output_name=converted_path,
         main_sheet_name=root_list_path,
         root_list_path=root_list_path,
-        root_id=lib_cove_config.config['root_id'],
+        root_id=root_id,
         schema=schema_url,
         disable_local_refs=lib_cove_config.config['flatten_tool']['disable_local_refs'],
         remove_empty_schema_columns=lib_cove_config.config['flatten_tool']['remove_empty_schema_columns'],

--- a/libcove/lib/converters.py
+++ b/libcove/lib/converters.py
@@ -118,16 +118,22 @@ def convert_spreadsheet(upload_dir, upload_url, file_name, file_type, lib_cove_c
     return context
 
 
-def convert_json(upload_dir, upload_url, file_name, lib_cove_config,
+def convert_json(upload_dir, upload_url, file_name, lib_cove_config, root_list_path=None, root_id=None,
                  schema_url=None, replace=False, request=None, flatten=False, cache=True, xml=False):
     context = {}
     converted_path = os.path.join(upload_dir, 'flattened')
 
+    if root_list_path is None:
+        root_list_path = lib_cove_config.config['root_list_path']
+
+    if root_id is None:
+        root_id = lib_cove_config.config['root_id']
+
     flatten_kwargs = dict(
         output_name=converted_path,
-        main_sheet_name=lib_cove_config.config['root_list_path'],
-        root_list_path=lib_cove_config.config['root_list_path'],
-        root_id=lib_cove_config.config['root_id'],
+        main_sheet_name=root_list_path,
+        root_list_path=root_list_path,
+        root_id=root_id,
         schema=schema_url,
         disable_local_refs=lib_cove_config.config['flatten_tool']['disable_local_refs'],
         remove_empty_schema_columns=lib_cove_config.config['flatten_tool']['remove_empty_schema_columns'],

--- a/libcove/lib/converters.py
+++ b/libcove/lib/converters.py
@@ -118,22 +118,16 @@ def convert_spreadsheet(upload_dir, upload_url, file_name, file_type, lib_cove_c
     return context
 
 
-def convert_json(upload_dir, upload_url, file_name, lib_cove_config, root_list_path=None, root_id=None,
+def convert_json(upload_dir, upload_url, file_name, lib_cove_config,
                  schema_url=None, replace=False, request=None, flatten=False, cache=True, xml=False):
     context = {}
     converted_path = os.path.join(upload_dir, 'flattened')
 
-    if root_list_path is None:
-        root_list_path = lib_cove_config.config['root_list_path']
-
-    if root_id is None:
-        root_id = lib_cove_config.config['root_id']
-
     flatten_kwargs = dict(
         output_name=converted_path,
-        main_sheet_name=root_list_path,
-        root_list_path=root_list_path,
-        root_id=root_id,
+        main_sheet_name=lib_cove_config.config['root_list_path'],
+        root_list_path=lib_cove_config.config['root_list_path'],
+        root_id=lib_cove_config.config['root_id'],
         schema=schema_url,
         disable_local_refs=lib_cove_config.config['flatten_tool']['disable_local_refs'],
         remove_empty_schema_columns=lib_cove_config.config['flatten_tool']['remove_empty_schema_columns'],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='libcove',
-    version='0.9.0',
+    version='0.10.0',
     author='Open Data Services',
     author_email='code@opendataservices.coop',
     url='https://github.com/OpenDataServices/lib-cove',

--- a/tests/lib/test_converters.py
+++ b/tests/lib/test_converters.py
@@ -52,8 +52,9 @@ def test_convert_xml_1():
     )
 
     lib_cove_config = LibCoveConfig()
+    lib_cove_config.config['root_list_path'] = 'iati-activity'
     output = convert_json(cove_temp_folder, "", xml_filename, lib_cove_config, flatten=True,
-                          xml=True, root_list_path='iati-activity')
+                          xml=True)
 
     assert output['converted_url'] == '/flattened'
     assert len(output['conversion_warning_messages']) == 0
@@ -89,6 +90,7 @@ def test_convert_json_root_is_list_1():
 
     lib_cove_config = LibCoveConfig()
     lib_cove_config.config['root_is_list'] = True
+    lib_cove_config.config['root_list_path'] = 'main'
     output = convert_json(cove_temp_folder, "", json_filename, lib_cove_config, flatten=True)
 
     assert output['converted_url'] == '/flattened'

--- a/tests/lib/test_converters.py
+++ b/tests/lib/test_converters.py
@@ -52,9 +52,8 @@ def test_convert_xml_1():
     )
 
     lib_cove_config = LibCoveConfig()
-    lib_cove_config.config['root_list_path'] = 'iati-activity'
     output = convert_json(cove_temp_folder, "", xml_filename, lib_cove_config, flatten=True,
-                          xml=True)
+                          xml=True, root_list_path='iati-activity')
 
     assert output['converted_url'] == '/flattened'
     assert len(output['conversion_warning_messages']) == 0
@@ -90,7 +89,6 @@ def test_convert_json_root_is_list_1():
 
     lib_cove_config = LibCoveConfig()
     lib_cove_config.config['root_is_list'] = True
-    lib_cove_config.config['root_list_path'] = 'main'
     output = convert_json(cove_temp_folder, "", json_filename, lib_cove_config, flatten=True)
 
     assert output['converted_url'] == '/flattened'


### PR DESCRIPTION
part of https://github.com/OpenDataServices/cove/issues/1208

Allows the organisation-identifier to be present when converting IATI XML data.
`root_id` is passed as an optional parameter to `convert_json`