### PR TITLE
Format code with black and isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,7 @@
+# From https://black.readthedocs.io/en/stable/the_black_code_style.html?highlight=isort#how-black-wraps-lines
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ python:
   - "3.6"
   - "3.5"
 install:
+  # Black only runs under Python >= 3.6
+  - if [[ $TRAVIS_PYTHON_VERSION != 3.5 ]]; then pip install black; fi
   - pip install -r requirements_dev.txt
 script:
+  - if [[ $TRAVIS_PYTHON_VERSION != 3.5 ]]; then black --check *.py */; fi
+  - isort --check-only --recursive *.py */
   - flake8
   - python -m pytest tests/

--- a/libcove/config.py
+++ b/libcove/config.py
@@ -1,15 +1,15 @@
 LIB_COVE_CONFIG_DEFAULT = {
-    'flatten_tool': {
-        'disable_local_refs': True,
-        'remove_empty_schema_columns': True,
-        'xml_comment': None,
+    "flatten_tool": {
+        "disable_local_refs": True,
+        "remove_empty_schema_columns": True,
+        "xml_comment": None,
     },
-    'root_list_path': 'main',
-    'root_id': 'main',
-    'root_is_list': False,
-    'id_name': 'id',
-    'convert_titles': False,
-    'cache_all_requests': False,
+    "root_list_path": "main",
+    "root_id": "main",
+    "root_is_list": False,
+    "id_name": "id",
+    "convert_titles": False,
+    "cache_all_requests": False,
 }
 
 

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -25,27 +25,35 @@ from django.utils.html import escape, conditional_escape, format_html
 
 # Because we will be changing items on this validator, it's important we take a copy!
 # Otherwise we could cause conflicts with other software in the same process.
-validator = jsonschema.validators.extend(jsonschema.validators.Draft4Validator, validators={})
+validator = jsonschema.validators.extend(
+    jsonschema.validators.Draft4Validator, validators={}
+)
 
 uniqueItemsValidator = validator.VALIDATORS.pop("uniqueItems")
-LANGUAGE_RE = re.compile("^(.*_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$") # noqa
-validation_error_template_lookup = {'date-time': 'Date is not in the correct format',
-                           'uri': 'Invalid \'uri\' found',
-                           'string': '{}\'{}\' is not a string. Check that the value {} has quotes at the start and end. Escape any quotes in the value with \'\\\'', # noqa
-                           'integer': '{}\'{}\' is not a integer. Check that the value {} doesn’t contain decimal points or any characters other than 0-9. Integer values should not be in quotes. ', # noqa
-                           'number': '{}\'{}\' is not a number. Check that the value {} doesn’t contain any characters other than 0-9 and dot (\'.\'). Number values should not be in quotes. ', # noqa
-                           'object': '{}\'{}\' is not a JSON object',
-                           'array': '{}\'{}\' is not a JSON array'}
+LANGUAGE_RE = re.compile(
+    "^(.*_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$"
+)  # noqa
+validation_error_template_lookup = {
+    "date-time": "Date is not in the correct format",
+    "uri": "Invalid 'uri' found",
+    "string": "{}'{}' is not a string. Check that the value {} has quotes at the start and end. Escape any quotes in the value with '\\'",  # noqa
+    "integer": "{}'{}' is not a integer. Check that the value {} doesn’t contain decimal points or any characters other than 0-9. Integer values should not be in quotes. ",  # noqa
+    "number": "{}'{}' is not a number. Check that the value {} doesn’t contain any characters other than 0-9 and dot ('.'). Number values should not be in quotes. ",  # noqa
+    "object": "{}'{}' is not a JSON object",
+    "array": "{}'{}' is not a JSON array",
+}
 # These are "safe" html that we trust
 # Don't insert any values into these strings without ensuring escaping
 # e.g. using django's format_html function.
-validation_error_template_lookup_safe = {'date-time': 'Date is not in the correct format',
-                           'uri': 'Invalid \'uri\' found',
-                           'string': '{}<code>{}</code> is not a string. Check that the value {} has quotes at the start and end. Escape any quotes in the value with <code>\</code>', # noqa
-                           'integer': '{}<code>{}</code> is not a integer. Check that the value {} doesn’t contain decimal points or any characters other than 0-9. Integer values should not be in quotes. ', # noqa
-                           'number': '{}<code>{}</code> is not a number. Check that the value {} doesn’t contain any characters other than 0-9 and dot (<code>.</code>). Number values should not be in quotes. ', # noqa
-                           'object': '{}<code>{}</code> is not a JSON object',
-                           'array': '{}<code>{}</code> is not a JSON array'}
+validation_error_template_lookup_safe = {
+    "date-time": "Date is not in the correct format",
+    "uri": "Invalid 'uri' found",
+    "string": "{}<code>{}</code> is not a string. Check that the value {} has quotes at the start and end. Escape any quotes in the value with <code>\</code>",  # noqa
+    "integer": "{}<code>{}</code> is not a integer. Check that the value {} doesn’t contain decimal points or any characters other than 0-9. Integer values should not be in quotes. ",  # noqa
+    "number": "{}<code>{}</code> is not a number. Check that the value {} doesn’t contain any characters other than 0-9 and dot (<code>.</code>). Number values should not be in quotes. ",  # noqa
+    "object": "{}<code>{}</code> is not a JSON object",
+    "array": "{}<code>{}</code> is not a JSON array",
+}
 
 
 def unique_ids(validator, ui, instance, schema):
@@ -54,11 +62,15 @@ def unique_ids(validator, ui, instance, schema):
         all_ids = set()
         for item in instance:
             try:
-                item_id = item.get('id')
+                item_id = item.get("id")
             except AttributeError:
                 # if item is not a dict
                 item_id = None
-            if item_id and not isinstance(item_id, list) and not isinstance(item_id, dict):
+            if (
+                item_id
+                and not isinstance(item_id, list)
+                and not isinstance(item_id, dict)
+            ):
                 if item_id in all_ids:
                     non_unique_ids.add(item_id)
                 all_ids.add(item_id)
@@ -102,24 +114,21 @@ def oneOf_draft4(validator, oneOf, instance, schema):
         if not errs:
             first_valid = subschema
             break
-        properties = subschema.get('properties', {})
-        if'statementType' in properties:
-            if 'statementType' in instance:
+        properties = subschema.get("properties", {})
+        if "statementType" in properties:
+            if "statementType" in instance:
                 try:
-                    validStatementType = properties['statementType'].get('enum', [])[0]
+                    validStatementType = properties["statementType"].get("enum", [])[0]
                 except IndexError:
                     continue
-                if instance['statementType'] == validStatementType:
+                if instance["statementType"] == validStatementType:
                     for err in errs:
                         yield err
                     return
                 else:
                     validStatementTypes.append(validStatementType)
             else:
-                yield ValidationError(
-                    'statementType',
-                    validator='required',
-                )
+                yield ValidationError("statementType", validator="required")
                 break
         # We check the title, because we don't have access to the field name,
         # as it lives in the parent.
@@ -159,7 +168,7 @@ def oneOf_draft4(validator, oneOf, instance, schema):
                     "linked releases. Embedded releases contain an 'id' whereas linked "
                     "releases do not. Your releases contain a mixture."
                 )
-                err.error_id = 'releases_both_embedded_and_linked'
+                err.error_id = "releases_both_embedded_and_linked"
                 yield err
                 break
 
@@ -167,15 +176,15 @@ def oneOf_draft4(validator, oneOf, instance, schema):
     else:
         if validStatementTypes:
             yield ValidationError(
-                'Invalid code found in statementType',
-                instance=instance['statementType'],
-                path=('statementType',),
-                validator='enum',
+                "Invalid code found in statementType",
+                instance=instance["statementType"],
+                path=("statementType",),
+                validator="enum",
             )
         else:
             yield ValidationError(
-                "%s is not valid under any of the given schemas" % (
-                    json.dumps(instance, sort_keys=True, default=decimal_default),),
+                "%s is not valid under any of the given schemas"
+                % (json.dumps(instance, sort_keys=True, default=decimal_default),),
                 context=all_errors,
             )
 
@@ -183,9 +192,7 @@ def oneOf_draft4(validator, oneOf, instance, schema):
     if more_valid:
         more_valid.append(first_valid)
         reprs = ", ".join(repr(schema) for schema in more_valid)
-        yield ValidationError(
-            "%r is valid under each of %s" % (instance, reprs)
-        )
+        yield ValidationError("%r is valid under each of %s" % (instance, reprs))
 
 
 validator.VALIDATORS.pop("patternProperties")
@@ -197,21 +204,25 @@ validator.VALIDATORS["oneOf"] = oneOf_draft4
 # Properties this class might look for
 # * cache_schema, boolean. This is deprecated, use the 'cache_all_requests' option in config instead
 # * config, an instance of a config class.
-class SchemaJsonMixin():
+class SchemaJsonMixin:
     @cached_property
     def release_schema_str(self):
-        response = get_request(self.release_schema_url,
-                               config=getattr(self, 'config', None),
-                               force_cache=getattr(self, 'cache_schema', False))
+        response = get_request(
+            self.release_schema_url,
+            config=getattr(self, "config", None),
+            force_cache=getattr(self, "cache_schema", False),
+        )
         return response.text
 
     @cached_property
     def release_pkg_schema_str(self):
         uri_scheme = urlparse(self.release_pkg_schema_url).scheme
-        if uri_scheme == 'http' or uri_scheme == 'https':
-            response = get_request(self.release_pkg_schema_url,
-                                   config=getattr(self, 'config', None),
-                                   force_cache=getattr(self, 'cache_schema', False))
+        if uri_scheme == "http" or uri_scheme == "https":
+            response = get_request(
+                self.release_pkg_schema_url,
+                config=getattr(self, "config", None),
+                force_cache=getattr(self, "cache_schema", False),
+            )
             return response.text
         else:
             with open(self.release_pkg_schema_url) as fp:
@@ -243,48 +254,58 @@ class SchemaJsonMixin():
         return self._release_pkg_schema_obj
 
     def get_release_pkg_schema_fields(self):
-        return set(schema_dict_fields_generator(self.get_release_pkg_schema_obj(deref=True)))
+        return set(
+            schema_dict_fields_generator(self.get_release_pkg_schema_obj(deref=True))
+        )
 
 
 def schema_dict_fields_generator(schema_dict):
-    if 'properties' in schema_dict and isinstance(schema_dict['properties'], dict):
-        for property_name, value in schema_dict['properties'].items():
-            if 'oneOf' in value:
-                property_schema_dicts = value['oneOf']
+    if "properties" in schema_dict and isinstance(schema_dict["properties"], dict):
+        for property_name, value in schema_dict["properties"].items():
+            if "oneOf" in value:
+                property_schema_dicts = value["oneOf"]
             else:
                 property_schema_dicts = [value]
             for property_schema_dict in property_schema_dicts:
                 if not isinstance(property_schema_dict, dict):
                     continue
                 property_type_set = get_property_type_set(property_schema_dict)
-                if 'object' in property_type_set:
+                if "object" in property_type_set:
                     for field in schema_dict_fields_generator(property_schema_dict):
-                        yield '/' + property_name + field
-                elif 'array' in property_type_set:
-                    fields = schema_dict_fields_generator(property_schema_dict.get('items', {}))
+                        yield "/" + property_name + field
+                elif "array" in property_type_set:
+                    fields = schema_dict_fields_generator(
+                        property_schema_dict.get("items", {})
+                    )
                     for field in fields:
-                        yield '/' + property_name + field
-                yield '/' + property_name
-    if 'items' in schema_dict and isinstance(schema_dict['items'], dict):
-        if 'oneOf' in schema_dict['items'] and isinstance(schema_dict['items']['oneOf'], list):
-            for oneOf in schema_dict['items']['oneOf']:
+                        yield "/" + property_name + field
+                yield "/" + property_name
+    if "items" in schema_dict and isinstance(schema_dict["items"], dict):
+        if "oneOf" in schema_dict["items"] and isinstance(
+            schema_dict["items"]["oneOf"], list
+        ):
+            for oneOf in schema_dict["items"]["oneOf"]:
                 for field in schema_dict_fields_generator(oneOf):
                     yield field
 
 
-def get_schema_codelist_paths(schema_obj, obj=None, current_path=(), codelist_paths=None, use_extensions=False):
-    '''Get a dict of codelist paths including the filename and if they are open.
+def get_schema_codelist_paths(
+    schema_obj, obj=None, current_path=(), codelist_paths=None, use_extensions=False
+):
+    """Get a dict of codelist paths including the filename and if they are open.
 
     codelist paths are given as tuples of tuples:
         {("path", "to", "codelist"): (filename, open?), ..}
-    '''
+    """
     if codelist_paths is None:
         codelist_paths = {}
 
     if schema_obj:
-        obj = schema_obj.get_release_pkg_schema_obj(deref=True, use_extensions=use_extensions)
+        obj = schema_obj.get_release_pkg_schema_obj(
+            deref=True, use_extensions=use_extensions
+        )
 
-    properties = obj.get('properties', {})
+    properties = obj.get("properties", {})
     if not isinstance(properties, dict):
         return codelist_paths
     for prop, value in properties.items():
@@ -294,12 +315,12 @@ def get_schema_codelist_paths(schema_obj, obj=None, current_path=(), codelist_pa
             path = (prop,)
 
         if "codelist" in value and path not in codelist_paths:
-            codelist_paths[path] = (value['codelist'], value.get('openCodelist', False))
+            codelist_paths[path] = (value["codelist"], value.get("openCodelist", False))
 
-        if value.get('type') == 'object':
+        if value.get("type") == "object":
             get_schema_codelist_paths(None, value, path, codelist_paths)
-        elif value.get('type') == 'array' and value.get('items', {}).get('properties'):
-            get_schema_codelist_paths(None, value['items'], path, codelist_paths)
+        elif value.get("type") == "array" and value.get("items", {}).get("properties"):
+            get_schema_codelist_paths(None, value["items"], path, codelist_paths)
 
     return codelist_paths
 
@@ -311,8 +332,8 @@ def load_codelist(url, config=None):
     response.raise_for_status()
     reader = csv.DictReader(line.decode("utf8") for line in response.iter_lines())
     for record in reader:
-        code = record.get('Code') or record.get('code')
-        title = record.get('Title') or record.get('Title_en')
+        code = record.get("Code") or record.get("code")
+        title = record.get("Title") or record.get("Title_en")
         if not code:
             return {}
         codelist_map[code] = title
@@ -342,8 +363,9 @@ def _deref_schema(schema_str, schema_host):
 
 
 class CustomJsonrefLoader(jsonref.JsonLoader):
-    '''This ref loader is only for use with the jsonref library
-    and NOT jsonschema.'''
+    """This ref loader is only for use with the jsonref library
+    and NOT jsonschema."""
+
     def __init__(self, schema_url, **kwargs):
         self.schema_url = schema_url
         super().__init__(**kwargs)
@@ -352,105 +374,146 @@ class CustomJsonrefLoader(jsonref.JsonLoader):
         # ignore url in ref apart from last part
         uri_info = urlparse(uri)
         uri = urljoin(self.schema_url, os.path.basename(uri_info.path))
-        if 'http' in uri_info.scheme:
+        if "http" in uri_info.scheme:
             return super().get_remote_json(uri, **kwargs)
         else:
             with open(uri) as schema_file:
                 return json.load(schema_file, **kwargs)
 
 
-def common_checks_context(upload_dir, json_data, schema_obj, schema_name, context, extra_checkers=None,
-                          fields_regex=False, api=False, cache=True):
-    schema_version = getattr(schema_obj, 'version', None)
-    schema_version_choices = getattr(schema_obj, 'version_choices', None)
+def common_checks_context(
+    upload_dir,
+    json_data,
+    schema_obj,
+    schema_name,
+    context,
+    extra_checkers=None,
+    fields_regex=False,
+    api=False,
+    cache=True,
+):
+    schema_version = getattr(schema_obj, "version", None)
+    schema_version_choices = getattr(schema_obj, "version_choices", None)
 
     if schema_version:
         schema_version_display_choices = tuple(
-            (version, display_url[0]) for version, display_url in schema_version_choices.items()
+            (version, display_url[0])
+            for version, display_url in schema_version_choices.items()
         )
-        context['version_used'] = schema_version
+        context["version_used"] = schema_version
         if not api:
-            context.update({
-                'version_display_choices': schema_version_display_choices,
-                'version_used_display': schema_version_choices[schema_version][0]}
+            context.update(
+                {
+                    "version_display_choices": schema_version_display_choices,
+                    "version_used_display": schema_version_choices[schema_version][0],
+                }
             )
 
-    if schema_name == 'record-package-schema.json':
+    if schema_name == "record-package-schema.json":
         schema_fields = schema_obj.get_record_pkg_schema_fields()
     else:
         schema_fields = schema_obj.get_release_pkg_schema_fields()
 
-    additional_fields_all = get_additional_fields_info(json_data, schema_fields,
-                                                       context, fields_regex=fields_regex)
+    additional_fields_all = get_additional_fields_info(
+        json_data, schema_fields, context, fields_regex=fields_regex
+    )
 
-    additional_fields = sorted(get_counts_additional_fields(json_data, schema_obj, schema_name,
-                                                            context, fields_regex=fields_regex,
-                                                            additional_fields_info=additional_fields_all))
+    additional_fields = sorted(
+        get_counts_additional_fields(
+            json_data,
+            schema_obj,
+            schema_name,
+            context,
+            fields_regex=fields_regex,
+            additional_fields_info=additional_fields_all,
+        )
+    )
 
     additional_fields_count = sum(item[2] for item in additional_fields)
-    additional_fields_all = get_additional_fields_info(json_data, schema_fields,
-                                                       context, fields_regex=fields_regex)
+    additional_fields_all = get_additional_fields_info(
+        json_data, schema_fields, context, fields_regex=fields_regex
+    )
 
-    context.update({
-        'data_only': additional_fields,
-        'additional_fields': additional_fields_all,
-        'additional_fields_count': additional_fields_count
-    })
+    context.update(
+        {
+            "data_only": additional_fields,
+            "additional_fields": additional_fields_all,
+            "additional_fields_count": additional_fields_count,
+        }
+    )
 
     cell_source_map = {}
     heading_source_map = {}
-    if context['file_type'] != 'json':  # Assume it is csv or xlsx
-        with open(os.path.join(upload_dir, 'cell_source_map.json')) as cell_source_map_fp:
+    if context["file_type"] != "json":  # Assume it is csv or xlsx
+        with open(
+            os.path.join(upload_dir, "cell_source_map.json")
+        ) as cell_source_map_fp:
             cell_source_map = json.load(cell_source_map_fp)
 
-        with open(os.path.join(upload_dir, 'heading_source_map.json')) as heading_source_map_fp:
+        with open(
+            os.path.join(upload_dir, "heading_source_map.json")
+        ) as heading_source_map_fp:
             heading_source_map = json.load(heading_source_map_fp)
 
     # IMPORTANT: If you change this filename, you must change it also in cove/views.py
     # Otherwsie people can upload a file with this name and inject HTML.
-    validation_errors_path = os.path.join(upload_dir, 'validation_errors-3.json')
+    validation_errors_path = os.path.join(upload_dir, "validation_errors-3.json")
     if os.path.exists(validation_errors_path):
         with open(validation_errors_path) as validation_error_fp:
             validation_errors = json.load(validation_error_fp)
     else:
-        validation_errors = get_schema_validation_errors(json_data, schema_obj, schema_name,
-                                                         cell_source_map, heading_source_map,
-                                                         extra_checkers=extra_checkers)
+        validation_errors = get_schema_validation_errors(
+            json_data,
+            schema_obj,
+            schema_name,
+            cell_source_map,
+            heading_source_map,
+            extra_checkers=extra_checkers,
+        )
         if cache:
-            with open(validation_errors_path, 'w+') as validation_error_fp:
-                json.dump(validation_errors, validation_error_fp, sort_keys=True, indent=2, default=decimal_default)
+            with open(validation_errors_path, "w+") as validation_error_fp:
+                json.dump(
+                    validation_errors,
+                    validation_error_fp,
+                    sort_keys=True,
+                    indent=2,
+                    default=decimal_default,
+                )
 
     extensions = None
-    if getattr(schema_obj, 'extensions', None):
+    if getattr(schema_obj, "extensions", None):
         extensions = {
-            'extensions': schema_obj.extensions,
-            'invalid_extension': schema_obj.invalid_extension,
-            'is_extended_schema': schema_obj.extended,
-            'extended_schema_url': schema_obj.extended_schema_url
+            "extensions": schema_obj.extensions,
+            "invalid_extension": schema_obj.invalid_extension,
+            "is_extended_schema": schema_obj.extended,
+            "extended_schema_url": schema_obj.extended_schema_url,
         }
 
-    context.update({
-        'schema_url': schema_obj.release_pkg_schema_url,
-        'extensions': extensions,
-        'validation_errors': sorted(validation_errors.items()),
-        'validation_errors_count': sum(len(value) for value in validation_errors.values()),
-        'common_error_types': []
-    })
+    context.update(
+        {
+            "schema_url": schema_obj.release_pkg_schema_url,
+            "extensions": extensions,
+            "validation_errors": sorted(validation_errors.items()),
+            "validation_errors_count": sum(
+                len(value) for value in validation_errors.values()
+            ),
+            "common_error_types": [],
+        }
+    )
 
     json_data_gen_paths = get_json_data_generic_paths(json_data)
-    context['deprecated_fields'] = get_json_data_deprecated_fields(json_data_gen_paths, schema_obj)
+    context["deprecated_fields"] = get_json_data_deprecated_fields(
+        json_data_gen_paths, schema_obj
+    )
 
     missing_ids = get_json_data_missing_ids(json_data_gen_paths, schema_obj)
     if missing_ids:
-        context.update({'structure_warnings': {'missing_ids': missing_ids}})
+        context.update({"structure_warnings": {"missing_ids": missing_ids}})
 
     if not api:
-        context['json_data'] = json_data
+        context["json_data"] = json_data
 
-    return {
-        'context': context,
-        'cell_source_map': cell_source_map,
-    }
+    return {"context": context, "cell_source_map": cell_source_map}
 
 
 def get_additional_codelist_values(schema_obj, json_data):
@@ -476,13 +539,13 @@ def get_additional_codelist_values(schema_obj, json_data):
             if str(value) in codelist_values:
                 continue
 
-            path_string = '/'.join(path_no_num)
+            path_string = "/".join(path_no_num)
 
             if path_string not in additional_codelist_values:
 
                 codelist_url = schema_obj.codelists + codelist
                 codelist_amend_urls = []
-                if hasattr(schema_obj, 'extended_codelist_urls'):
+                if hasattr(schema_obj, "extended_codelist_urls"):
 
                     # Replace URL if this codelist is overridden by an extension.
                     # Last one to be applied wins.
@@ -493,11 +556,15 @@ def get_additional_codelist_values(schema_obj, json_data):
                     codelistsub = "-" + codelist
                     for codelist_key in schema_obj.extended_codelist_urls.keys():
                         if codelist_key == codelistadd:
-                            for amended_codelist in schema_obj.extended_codelist_urls[codelist_key]:
-                                codelist_amend_urls.append(('+', amended_codelist))
+                            for amended_codelist in schema_obj.extended_codelist_urls[
+                                codelist_key
+                            ]:
+                                codelist_amend_urls.append(("+", amended_codelist))
                         if codelist_key == codelistsub:
-                            for amended_codelist in schema_obj.extended_codelist_urls[codelist_key]:
-                                codelist_amend_urls.append(('-', amended_codelist))
+                            for amended_codelist in schema_obj.extended_codelist_urls[
+                                codelist_key
+                            ]:
+                                codelist_amend_urls.append(("-", amended_codelist))
 
                 additional_codelist_values[path_string] = {
                     "path": "/".join(path_no_num[:-1]),
@@ -511,11 +578,11 @@ def get_additional_codelist_values(schema_obj, json_data):
                     # "location_values": []
                 }
 
-            additional_codelist_values['/'.join(path_no_num)]['values'].add(str(value))
+            additional_codelist_values["/".join(path_no_num)]["values"].add(str(value))
             # additional_codelist_values['/'.join(path_no_num)]['location_values'].append((path, value))
 
     for codelist_value in additional_codelist_values.values():
-        codelist_value['values'] = sorted(list(codelist_value['values']))
+        codelist_value["values"] = sorted(list(codelist_value["values"]))
     return additional_codelist_values
 
 
@@ -529,43 +596,62 @@ def get_additional_fields_info(json_data, schema_fields, context, fields_regex=F
 
         if field in schema_fields:
             continue
-        if fields_regex and LANGUAGE_RE.search(field.split('/')[-1]):
+        if fields_regex and LANGUAGE_RE.search(field.split("/")[-1]):
             continue
 
         for root_additional_field in root_additional_fields:
             if field.startswith(root_additional_field):
-                field_info['root_additional_field'] = False
-                additional_fields[root_additional_field]['additional_field_descendance'][field] = field_info
+                field_info["root_additional_field"] = False
+                additional_fields[root_additional_field][
+                    "additional_field_descendance"
+                ][field] = field_info
                 break
         else:
-            field_info['root_additional_field'] = True
-            field_info['additional_field_descendance'] = collections.OrderedDict()
+            field_info["root_additional_field"] = True
+            field_info["additional_field_descendance"] = collections.OrderedDict()
             root_additional_fields.add(field)
 
-        field_info['path'] = '/'.join(field.split('/')[:-1])
-        field_info['field_name'] = field.split('/')[-1]
+        field_info["path"] = "/".join(field.split("/")[:-1])
+        field_info["field_name"] = field.split("/")[-1]
         additional_fields[field] = field_info
 
     return additional_fields
 
 
-def get_counts_additional_fields(json_data, schema_obj, schema_name, context,
-                                 fields_regex=False, additional_fields_info=None):
+def get_counts_additional_fields(
+    json_data,
+    schema_obj,
+    schema_name,
+    context,
+    fields_regex=False,
+    additional_fields_info=None,
+):
 
     if not additional_fields_info:
-        if schema_name == 'record-package-schema.json':
+        if schema_name == "record-package-schema.json":
             schema_fields = schema_obj.get_record_pkg_schema_fields()
         else:
             schema_fields = schema_obj.get_release_pkg_schema_fields()
-        additional_fields_info = get_additional_fields_info(json_data, schema_fields, context, fields_regex=False)
+        additional_fields_info = get_additional_fields_info(
+            json_data, schema_fields, context, fields_regex=False
+        )
 
-    return [(field_info['path'], field_info['field_name'], field_info['count'])
-            for field, field_info in additional_fields_info.items()
-            if field_info['root_additional_field']]
+    return [
+        (field_info["path"], field_info["field_name"], field_info["count"])
+        for field, field_info in additional_fields_info.items()
+        if field_info["root_additional_field"]
+    ]
 
 
-def get_schema_validation_errors(json_data, schema_obj, schema_name, cell_src_map, heading_src_map, extra_checkers=None): # noqa
-    if schema_name == 'record-package-schema.json':
+def get_schema_validation_errors(
+    json_data,
+    schema_obj,
+    schema_name,
+    cell_src_map,
+    heading_src_map,
+    extra_checkers=None,
+):  # noqa
+    if schema_name == "record-package-schema.json":
         pkg_schema_obj = schema_obj.get_record_pkg_schema_obj()
     else:
         pkg_schema_obj = schema_obj.get_release_pkg_schema_obj()
@@ -575,19 +661,29 @@ def get_schema_validation_errors(json_data, schema_obj, schema_name, cell_src_ma
     if extra_checkers:
         format_checker.checkers.update(extra_checkers)
 
-    if getattr(schema_obj, 'extended', None):
-        resolver = CustomRefResolver('', pkg_schema_obj, schema_url=schema_obj.schema_host,
-                                     schema_file=schema_obj.extended_schema_file,
-                                     file_schema_name=schema_obj.release_schema_name)
+    if getattr(schema_obj, "extended", None):
+        resolver = CustomRefResolver(
+            "",
+            pkg_schema_obj,
+            schema_url=schema_obj.schema_host,
+            schema_file=schema_obj.extended_schema_file,
+            file_schema_name=schema_obj.release_schema_name,
+        )
     else:
-        resolver = CustomRefResolver('', pkg_schema_obj, schema_url=schema_obj.schema_host)
+        resolver = CustomRefResolver(
+            "", pkg_schema_obj, schema_url=schema_obj.schema_host
+        )
 
-    our_validator = validator(pkg_schema_obj, format_checker=format_checker, resolver=resolver)
+    our_validator = validator(
+        pkg_schema_obj, format_checker=format_checker, resolver=resolver
+    )
     for e in our_validator.iter_errors(json_data):
         message_safe = None
         message = e.message
         path = "/".join(str(item) for item in e.path)
-        path_no_number = "/".join(str(item) for item in e.path if not isinstance(item, int))
+        path_no_number = "/".join(
+            str(item) for item in e.path if not isinstance(item, int)
+        )
 
         value = {"path": path}
         cell_reference = cell_src_map.get(path)
@@ -595,11 +691,13 @@ def get_schema_validation_errors(json_data, schema_obj, schema_name, cell_src_ma
         if cell_reference:
             first_reference = cell_reference[0]
             if len(first_reference) == 4:
-                value["sheet"], value["col_alpha"], value["row_number"], value["header"] = first_reference
+                value["sheet"], value["col_alpha"], value["row_number"], value[
+                    "header"
+                ] = first_reference
             if len(first_reference) == 2:
                 value["sheet"], value["row_number"] = first_reference
 
-        header = value.get('header')
+        header = value.get("header")
 
         header_extra = None
         pre_header = ""
@@ -609,38 +707,46 @@ def get_schema_validation_errors(json_data, schema_obj, schema_name, cell_src_ma
             if isinstance(e.path[-1], int) and len(e.path) >= 2:
                 # We're dealing with elements in an array of items at this point
                 pre_header = "Array Element "
-                header_extra = '{}/{}'.format(e.path[-2], e.path[-1])
+                header_extra = "{}/{}".format(e.path[-2], e.path[-1])
 
-        null_clause = ''
+        null_clause = ""
         validator_type = e.validator
-        if e.validator in ('format', 'type'):
+        if e.validator in ("format", "type"):
             validator_type = e.validator_value
             if isinstance(e.validator_value, list):
                 validator_type = e.validator_value[0]
-                if 'null' not in e.validator_value:
-                    null_clause = 'is not null, and'
+                if "null" not in e.validator_value:
+                    null_clause = "is not null, and"
             else:
-                null_clause = 'is not null, and'
+                null_clause = "is not null, and"
 
-            message_template = validation_error_template_lookup.get(validator_type, message)
-            message_safe_template = validation_error_template_lookup_safe.get(validator_type)
+            message_template = validation_error_template_lookup.get(
+                validator_type, message
+            )
+            message_safe_template = validation_error_template_lookup_safe.get(
+                validator_type
+            )
 
             if message_template:
                 message = message_template.format(pre_header, header, null_clause)
 
             if message_safe_template:
-                message_safe = format_html(message_safe_template, pre_header, header, null_clause)
+                message_safe = format_html(
+                    message_safe_template, pre_header, header, null_clause
+                )
 
-        if e.validator == 'oneOf' and e.validator_value[0] == {'format': 'date-time'}:
+        if e.validator == "oneOf" and e.validator_value[0] == {"format": "date-time"}:
             # Give a nice date related error message for 360Giving date `oneOf`s.
-            message = validation_error_template_lookup['date-time']
-            message_safe = format_html(validation_error_template_lookup_safe['date-time'])
-            validator_type = 'date-time'
+            message = validation_error_template_lookup["date-time"]
+            message_safe = format_html(
+                validation_error_template_lookup_safe["date-time"]
+            )
+            validator_type = "date-time"
 
         if not isinstance(e.instance, (dict, list)):
             value["value"] = e.instance
 
-        if e.validator == 'required':
+        if e.validator == "required":
             field_name = e.message
             parent_name = None
             if len(e.path) > 2:
@@ -649,32 +755,50 @@ def get_schema_validation_errors(json_data, schema_obj, schema_name, cell_src_ma
                 else:
                     parent_name = e.path[-1]
 
-            heading = heading_src_map.get(path_no_number + '/' + e.message)
+            heading = heading_src_map.get(path_no_number + "/" + e.message)
             if heading:
                 field_name = heading[0][1]
-                value['header'] = heading[0][1]
+                value["header"] = heading[0][1]
             header = field_name
             if parent_name:
-                message = "'{}' is missing but required within '{}'".format(field_name, parent_name)
-                message_safe = format_html("<code>{}</code> is missing but required within <code>{}</code>", field_name, parent_name) # noqa
+                message = "'{}' is missing but required within '{}'".format(
+                    field_name, parent_name
+                )
+                message_safe = format_html(
+                    "<code>{}</code> is missing but required within <code>{}</code>",
+                    field_name,
+                    parent_name,
+                )  # noqa
             else:
                 message = "'{}' is missing but required".format(field_name)
-                message_safe = format_html("<code>{}</code> is missing but required", field_name, parent_name)
+                message_safe = format_html(
+                    "<code>{}</code> is missing but required", field_name, parent_name
+                )
 
-        if e.validator == 'enum':
+        if e.validator == "enum":
             if "isCodelist" in e.schema:
                 continue
             message = "Invalid code found in '{}'".format(header)
             message_safe = format_html("Invalid code found in <code>{}</code>", header)
 
-        if e.validator == 'pattern':
-            message_safe = format_html('<code>{}</code> does not match the regex <code>{}</code>', header, e.validator_value) # noqa
+        if e.validator == "pattern":
+            message_safe = format_html(
+                "<code>{}</code> does not match the regex <code>{}</code>",
+                header,
+                e.validator_value,
+            )  # noqa
 
-        if e.validator == 'minItems' and e.validator_value == 1:
-            message_safe = format_html('<code>{}</code> is too short. You must supply at least one value, or remove the item entirely (unless it’s required).', e.instance) # noqa
+        if e.validator == "minItems" and e.validator_value == 1:
+            message_safe = format_html(
+                "<code>{}</code> is too short. You must supply at least one value, or remove the item entirely (unless it’s required).",
+                e.instance,
+            )  # noqa
 
-        if e.validator == 'minLength' and e.validator_value == 1:
-            message_safe = format_html('<code>"{}"</code> is too short. Strings must be at least one character. This error typically indicates a missing value.', e.instance) # noqa
+        if e.validator == "minLength" and e.validator_value == 1:
+            message_safe = format_html(
+                '<code>"{}"</code> is too short. Strings must be at least one character. This error typically indicates a missing value.',
+                e.instance,
+            )  # noqa
 
         if message_safe is None:
             message_safe = escape(message)
@@ -682,28 +806,35 @@ def get_schema_validation_errors(json_data, schema_obj, schema_name, cell_src_ma
         if header_extra is None:
             header_extra = header
 
-        unique_validator_key = OrderedDict([
-            ('message', message),
-            ('message_safe', conditional_escape(message_safe)),
-            ('validator', e.validator),
-            ('assumption', e.assumption if hasattr(e, 'assumption') else None),
-            # Don't pass this value for 'enum' and 'required' validators,
-            # because it is not needed, and it will mean less grouping, which
-            # we don't want.
-            ('validator_value', e.validator_value if e.validator not in ['enum', 'required'] else None),
-            ('message_type', validator_type),
-            ('path_no_number', path_no_number),
-            ('header', header),
-            ('header_extra', header_extra),
-            ('null_clause', null_clause),
-            ('error_id', e.error_id if hasattr(e, 'error_id') else None),
-        ])
+        unique_validator_key = OrderedDict(
+            [
+                ("message", message),
+                ("message_safe", conditional_escape(message_safe)),
+                ("validator", e.validator),
+                ("assumption", e.assumption if hasattr(e, "assumption") else None),
+                # Don't pass this value for 'enum' and 'required' validators,
+                # because it is not needed, and it will mean less grouping, which
+                # we don't want.
+                (
+                    "validator_value",
+                    e.validator_value
+                    if e.validator not in ["enum", "required"]
+                    else None,
+                ),
+                ("message_type", validator_type),
+                ("path_no_number", path_no_number),
+                ("header", header),
+                ("header_extra", header_extra),
+                ("null_clause", null_clause),
+                ("error_id", e.error_id if hasattr(e, "error_id") else None),
+            ]
+        )
         validation_errors[json.dumps(unique_validator_key)].append(value)
     return dict(validation_errors)
 
 
 def get_json_data_generic_paths(json_data, path=(), generic_paths=None):
-    '''Transform json data into a dictionary with keys made of json paths.
+    """Transform json data into a dictionary with keys made of json paths.
 
     Key are json paths (as tuples). Values are dictionaries with keys including specific
     indexes (which are not including in the top level keys), eg:
@@ -735,7 +866,7 @@ def get_json_data_generic_paths(json_data, path=(), generic_paths=None):
         },
         ('c', 'cb'): {('c', 2, 'cb'): 'cb'}
     }
-    '''
+    """
     if generic_paths is None:
         generic_paths = {}
 
@@ -764,7 +895,9 @@ def get_json_data_generic_paths(json_data, path=(), generic_paths=None):
 
 def get_json_data_deprecated_fields(json_data_paths, schema_obj):
     deprecated_schema_paths = _get_schema_deprecated_paths(schema_obj)
-    deprecated_json_data_paths = [path for path in deprecated_schema_paths if path[0] in json_data_paths]
+    deprecated_json_data_paths = [
+        path for path in deprecated_schema_paths if path[0] in json_data_paths
+    ]
     # Generate an OrderedDict sorted by deprecated field names (keys) mapping
     # to a unordered tuple of tuples:
     # {deprecated_field: ((path, path... ), (version, description))}
@@ -776,10 +909,15 @@ def get_json_data_deprecated_fields(json_data_paths, schema_obj):
         # e.g. (invalid OCDS data):
         # {"version":"1.1", "releases":{"buyer":{"additionalIdentifiers":[]}}}
         if hasattr(json_data_paths[generic_path[0]], "keys"):
-            deprecated_fields[generic_path[0][-1]] += (tuple(key for key in json_data_paths[generic_path[0]].keys()),
-                                                       generic_path[1])
+            deprecated_fields[generic_path[0][-1]] += (
+                tuple(key for key in json_data_paths[generic_path[0]].keys()),
+                generic_path[1],
+            )
         else:
-            deprecated_fields[generic_path[0][-1]] += ((generic_path[0],), generic_path[1])
+            deprecated_fields[generic_path[0][-1]] += (
+                (generic_path[0],),
+                generic_path[1],
+            )
 
     # Order the path tuples in values for deprecated_fields.
     deprecated_fields_output = OrderedDict()
@@ -789,10 +927,16 @@ def get_json_data_deprecated_fields(json_data_paths, schema_obj):
         # Avoid adding terminal paths for array indexes as only whole arrays can be deprecated.
         # TODO: check, is that true for all cases?
         slashed_paths = tuple(
-            ("/".join((map(str, sort_path[:-1])))
-             for sort_path in sorted_paths if type(sort_path[-1]) != int)
+            (
+                "/".join((map(str, sort_path[:-1])))
+                for sort_path in sorted_paths
+                if type(sort_path[-1]) != int
+            )
         )
-        deprecated_fields_output[field] = {"paths": slashed_paths, "explanation": paths[1]}
+        deprecated_fields_output[field] = {
+            "paths": slashed_paths,
+            "explanation": paths[1],
+        }
 
     return deprecated_fields_output
 
@@ -807,8 +951,10 @@ def get_json_data_missing_ids(json_data_paths, schema_obj):
             for specific_path in json_data_paths[generic_no_id]:
                 if type(specific_path[-1]) != int:
                     continue
-                if 'id' not in json_data_paths[generic_no_id][specific_path]:
-                    missing_ids_paths.append('/'.join(list(map(lambda i: str(i), specific_path)) + ['id']))
+                if "id" not in json_data_paths[generic_no_id][specific_path]:
+                    missing_ids_paths.append(
+                        "/".join(list(map(lambda i: str(i), specific_path)) + ["id"])
+                    )
 
     return sorted(missing_ids_paths)
 
@@ -835,34 +981,38 @@ def get_fields_present_with_examples(*args, **kwargs):
     counter = collections.OrderedDict()
     for key, value in fields_present_generator(*args, **kwargs):
         if key not in counter:
-            counter[key] = {'count': 0, 'examples': []}
-        counter[key]['count'] += 1
-        if len(counter[key]['examples']) < 3:
+            counter[key] = {"count": 0, "examples": []}
+        counter[key]["count"] += 1
+        if len(counter[key]["examples"]) < 3:
             if not isinstance(value, (list, dict)):
-                counter[key]['examples'].append(value)
+                counter[key]["examples"].append(value)
 
     return counter
 
 
 def get_fields_present(*args, **kwargs):
-    return {key: value['count'] for key, value in get_fields_present_with_examples(*args, **kwargs).items()}
+    return {
+        key: value["count"]
+        for key, value in get_fields_present_with_examples(*args, **kwargs).items()
+    }
 
 
 class CustomRefResolver(RefResolver):
-    '''This RefResolver is only for use with the jsonschema library'''
+    """This RefResolver is only for use with the jsonschema library"""
+
     def __init__(self, *args, **kw):
         # this is the name of the json file that you want replaced i.e release-schema.json
-        self.file_schema_name = kw.pop('file_schema_name', '')
+        self.file_schema_name = kw.pop("file_schema_name", "")
         # the path on the disk of the file you want to replace the ref
-        self.schema_file = kw.pop('schema_file', None)
+        self.schema_file = kw.pop("schema_file", None)
         # the url of the path to the schema. i.e https://standard.open-contracting.org/schema/1__1__1/
         # the name of the schema file is appended to this to make the full url.
         # this is ignored when you supply a file
-        self.schema_url = kw.pop('schema_url', '')
+        self.schema_url = kw.pop("schema_url", "")
         super().__init__(*args, **kw)
 
     def resolve_remote(self, uri):
-        schema_name = uri.split('/')[-1]
+        schema_name = uri.split("/")[-1]
         if self.schema_file and self.file_schema_name == schema_name:
             uri = self.schema_file
         else:
@@ -883,19 +1033,21 @@ class CustomRefResolver(RefResolver):
         return result
 
 
-def _get_schema_deprecated_paths(schema_obj, obj=None, current_path=(), deprecated_paths=None):
-    '''Get a list of deprecated paths and explanations for deprecation in a schema.
+def _get_schema_deprecated_paths(
+    schema_obj, obj=None, current_path=(), deprecated_paths=None
+):
+    """Get a list of deprecated paths and explanations for deprecation in a schema.
 
     Deprecated paths are given as tuples of tuples:
     ((path, to, field), (deprecation_version, description))
-    '''
+    """
     if deprecated_paths is None:
         deprecated_paths = []
 
     if schema_obj:
         obj = schema_obj.get_release_pkg_schema_obj(deref=True)
 
-    properties = obj.get('properties', {})
+    properties = obj.get("properties", {})
     if not isinstance(properties, dict):
         return deprecated_paths
     for prop, value in properties.items():
@@ -906,40 +1058,58 @@ def _get_schema_deprecated_paths(schema_obj, obj=None, current_path=(), deprecat
 
         if path not in deprecated_paths:
             if "deprecated" in value:
-                deprecated_paths.append((
-                    path,
-                    (value['deprecated']['deprecatedVersion'], value['deprecated']['description'])
-                ))
-            elif getattr(value, '__reference__', None) and "deprecated" in value.__reference__:
-                deprecated_paths.append((
-                    path,
-                    (value.__reference__['deprecated']['deprecatedVersion'],
-                     value.__reference__['deprecated']['description'])
-                ))
+                deprecated_paths.append(
+                    (
+                        path,
+                        (
+                            value["deprecated"]["deprecatedVersion"],
+                            value["deprecated"]["description"],
+                        ),
+                    )
+                )
+            elif (
+                getattr(value, "__reference__", None)
+                and "deprecated" in value.__reference__
+            ):
+                deprecated_paths.append(
+                    (
+                        path,
+                        (
+                            value.__reference__["deprecated"]["deprecatedVersion"],
+                            value.__reference__["deprecated"]["description"],
+                        ),
+                    )
+                )
 
-        if value.get('type') == 'object':
+        if value.get("type") == "object":
             _get_schema_deprecated_paths(None, value, path, deprecated_paths)
-        elif value.get('type') == 'array' and value.get('items', {}).get('properties'):
-            _get_schema_deprecated_paths(None, value['items'], path, deprecated_paths)
+        elif value.get("type") == "array" and value.get("items", {}).get("properties"):
+            _get_schema_deprecated_paths(None, value["items"], path, deprecated_paths)
 
     return deprecated_paths
 
 
-def _get_schema_non_required_ids(schema_obj, obj=None, current_path=(), id_paths=None,
-                                 array_parent=False, list_merge=False):
-    '''Get a list of paths for schema non-required object['id'] in arrays of objects.
+def _get_schema_non_required_ids(
+    schema_obj,
+    obj=None,
+    current_path=(),
+    id_paths=None,
+    array_parent=False,
+    list_merge=False,
+):
+    """Get a list of paths for schema non-required object['id'] in arrays of objects.
 
     Return a list of tuples with generic paths (i.e. no indexes for array paths).
     Types "array" in json schema objects with property `"wholeListMerge": true` will
     be skipped.
-    '''
+    """
     if id_paths is None:
         id_paths = []
     if schema_obj:
         obj = schema_obj.get_release_pkg_schema_obj(deref=True)
 
-    properties = obj.get('properties', {})
-    no_required_id = 'id' not in obj.get('required', [])
+    properties = obj.get("properties", {})
+    no_required_id = "id" not in obj.get("required", [])
 
     if not isinstance(properties, dict):
         return id_paths
@@ -949,32 +1119,38 @@ def _get_schema_non_required_ids(schema_obj, obj=None, current_path=(), id_paths
         else:
             path = (prop,)
 
-        if prop == 'id' and no_required_id and array_parent and not list_merge:
+        if prop == "id" and no_required_id and array_parent and not list_merge:
             id_paths.append(path)
 
-        if value.get('type') == 'object':
+        if value.get("type") == "object":
             _get_schema_non_required_ids(None, value, path, id_paths)
-        elif value.get('type') == 'array' and value.get('items', {}).get('properties'):
-            has_list_merge = 'wholeListMerge' in value and value.get('wholeListMerge')
-            _get_schema_non_required_ids(None, value['items'], path, id_paths,
-                                         array_parent=True, list_merge=has_list_merge)
+        elif value.get("type") == "array" and value.get("items", {}).get("properties"):
+            has_list_merge = "wholeListMerge" in value and value.get("wholeListMerge")
+            _get_schema_non_required_ids(
+                None,
+                value["items"],
+                path,
+                id_paths,
+                array_parent=True,
+                list_merge=has_list_merge,
+            )
 
     return id_paths
 
 
-def fields_present_generator(json_data, prefix=''):
+def fields_present_generator(json_data, prefix=""):
     if isinstance(json_data, dict):
         for key, value in json_data.items():
             if isinstance(value, list):
-                yield prefix + '/' + key, value
+                yield prefix + "/" + key, value
                 for item in value:
                     if isinstance(item, dict):
-                        yield from fields_present_generator(item, prefix + '/' + key)
+                        yield from fields_present_generator(item, prefix + "/" + key)
             elif isinstance(value, dict):
-                yield prefix + '/' + key, value
-                yield from fields_present_generator(value, prefix + '/' + key)
+                yield prefix + "/" + key, value
+                yield from fields_present_generator(value, prefix + "/" + key)
             else:
-                yield prefix + '/' + key, value
+                yield prefix + "/" + key, value
     elif isinstance(json_data, list):
         for item in json_data:
             if isinstance(item, dict):
@@ -982,21 +1158,21 @@ def fields_present_generator(json_data, prefix=''):
 
 
 def add_is_codelist(obj):
-    ''' This is needed so that we can detect enums that are arrays as the jsonschema library does not
+    """ This is needed so that we can detect enums that are arrays as the jsonschema library does not
     give you any parent information and the codelist property is on the parent in this case. Only applies to
-    release.tag in core schema at the moment.'''
+    release.tag in core schema at the moment."""
 
-    for prop, value in obj.get('properties', {}).items():
+    for prop, value in obj.get("properties", {}).items():
         if "codelist" in value:
-            if 'array' in value.get('type', ''):
-                value['items']['isCodelist'] = True
+            if "array" in value.get("type", ""):
+                value["items"]["isCodelist"] = True
             else:
-                value['isCodelist'] = True
+                value["isCodelist"] = True
 
-        if value.get('type') == 'object':
+        if value.get("type") == "object":
             add_is_codelist(value)
-        elif value.get('type') == 'array' and value.get('items', {}).get('properties'):
-            add_is_codelist(value['items'])
+        elif value.get("type") == "array" and value.get("items", {}).get("properties"):
+            add_is_codelist(value["items"])
 
     for value in obj.get("definitions", {}).values():
         if "properties" in value:
@@ -1004,12 +1180,14 @@ def add_is_codelist(obj):
 
 
 @cove_spreadsheet_conversion_error
-def get_spreadsheet_meta_data(upload_dir, file_name, schema, file_type='xlsx', name='Meta'):
-    if file_type == 'csv':
+def get_spreadsheet_meta_data(
+    upload_dir, file_name, schema, file_type="xlsx", name="Meta"
+):
+    if file_type == "csv":
         input_name = upload_dir
     else:
         input_name = file_name
-    output_name = os.path.join(upload_dir, 'metatab.json')
+    output_name = os.path.join(upload_dir, "metatab.json")
 
     unflatten(
         input_name=input_name,
@@ -1018,7 +1196,7 @@ def get_spreadsheet_meta_data(upload_dir, file_name, schema, file_type='xlsx', n
         metatab_only=True,
         metatab_schema=schema,
         metatab_name=name,
-        metatab_vertical_orientation=True
+        metatab_vertical_orientation=True,
     )
 
     with open(output_name) as metatab_data:
@@ -1027,31 +1205,31 @@ def get_spreadsheet_meta_data(upload_dir, file_name, schema, file_type='xlsx', n
 
 
 def get_orgids_prefixes(orgids_url=None):
-    '''Get org-ids.json file from file system (or fetch upstream if it doesn't exist)
+    """Get org-ids.json file from file system (or fetch upstream if it doesn't exist)
 
     A lock file is needed to avoid different processes trying to access the file
     trampling each other. If a process has the exclusive lock, a different process
     will wait until it is released.
-    '''
+    """
     local_org_ids_dir = os.path.dirname(os.path.realpath(__file__))
-    local_org_ids_file = os.path.join(local_org_ids_dir, 'org-ids.json')
-    lock_file = os.path.join(local_org_ids_dir, 'org-ids.json.lock')
+    local_org_ids_file = os.path.join(local_org_ids_dir, "org-ids.json")
+    lock_file = os.path.join(local_org_ids_dir, "org-ids.json.lock")
     today = datetime.date.today()
     get_remote_file = False
     first_request = False
 
     if not orgids_url:
-        orgids_url = 'http://org-id.guide/download.json'
+        orgids_url = "http://org-id.guide/download.json"
 
     if os.path.exists(local_org_ids_file):
-        with open(lock_file, 'w') as lock:
+        with open(lock_file, "w") as lock:
             fcntl.flock(lock, fcntl.LOCK_EX)
             fp = open(local_org_ids_file)
             org_ids = json.load(fp)
             fp.close()
             fcntl.flock(lock, fcntl.LOCK_UN)
-        date_str = org_ids.get('downloaded', '2000-1-1')
-        date_downloaded = datetime.datetime.strptime(date_str, '%Y-%m-%d').date()
+        date_str = org_ids.get("downloaded", "2000-1-1")
+        date_downloaded = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
         if date_downloaded != today:
             get_remote_file = True
     else:
@@ -1061,10 +1239,10 @@ def get_orgids_prefixes(orgids_url=None):
     if get_remote_file:
         try:
             org_ids = requests.get(orgids_url).json()
-            org_ids['downloaded'] = "%s" % today
-            with open(lock_file, 'w') as lock:
+            org_ids["downloaded"] = "%s" % today
+            with open(lock_file, "w") as lock:
                 fcntl.flock(lock, fcntl.LOCK_EX)
-                fp = open(local_org_ids_file, 'w')
+                fp = open(local_org_ids_file, "w")
                 json.dump(org_ids, fp, indent=2)
                 fp.close()
                 fcntl.flock(lock, fcntl.LOCK_UN)
@@ -1073,4 +1251,4 @@ def get_orgids_prefixes(orgids_url=None):
                 raise  # First time ever request fails
             pass  # Update fails
 
-    return [org_list['code'] for org_list in org_ids['lists']]
+    return [org_list["code"] for org_list in org_ids["lists"]]

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -1,27 +1,26 @@
-import json
-import jsonref
-import requests
-import csv
-import functools
-import os
-import re
 import collections
+import csv
 import datetime
 import fcntl
-
-from cached_property import cached_property
-from .tools import get_request, decimal_default
-from urllib.parse import urlparse, urljoin
+import functools
+import json
+import os
+import re
 from collections import OrderedDict
+from urllib.parse import urljoin, urlparse
+
+import jsonref
+import jsonschema.validators
+import requests
+from cached_property import cached_property
+from django.utils.html import conditional_escape, escape, format_html
 from flattentool import unflatten
 from flattentool.schema import get_property_type_set
 from jsonschema import FormatChecker, RefResolver
 from jsonschema.exceptions import ValidationError
-import jsonschema.validators
+
 from .exceptions import cove_spreadsheet_conversion_error
-
-
-from django.utils.html import escape, conditional_escape, format_html
+from .tools import decimal_default, get_request
 
 # Because we will be changing items on this validator, it's important we take a copy!
 # Otherwise we could cause conflicts with other software in the same process.

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -31,13 +31,13 @@ validator = jsonschema.validators.extend(
 uniqueItemsValidator = validator.VALIDATORS.pop("uniqueItems")
 LANGUAGE_RE = re.compile(
     "^(.*_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$"
-)  # noqa
+)
 validation_error_template_lookup = {
     "date-time": "Date is not in the correct format",
     "uri": "Invalid 'uri' found",
-    "string": "{}'{}' is not a string. Check that the value {} has quotes at the start and end. Escape any quotes in the value with '\\'",  # noqa
-    "integer": "{}'{}' is not a integer. Check that the value {} doesn’t contain decimal points or any characters other than 0-9. Integer values should not be in quotes. ",  # noqa
-    "number": "{}'{}' is not a number. Check that the value {} doesn’t contain any characters other than 0-9 and dot ('.'). Number values should not be in quotes. ",  # noqa
+    "string": "{}'{}' is not a string. Check that the value {} has quotes at the start and end. Escape any quotes in the value with '\\'",
+    "integer": "{}'{}' is not a integer. Check that the value {} doesn’t contain decimal points or any characters other than 0-9. Integer values should not be in quotes. ",
+    "number": "{}'{}' is not a number. Check that the value {} doesn’t contain any characters other than 0-9 and dot ('.'). Number values should not be in quotes. ",
     "object": "{}'{}' is not a JSON object",
     "array": "{}'{}' is not a JSON array",
 }
@@ -47,9 +47,9 @@ validation_error_template_lookup = {
 validation_error_template_lookup_safe = {
     "date-time": "Date is not in the correct format",
     "uri": "Invalid 'uri' found",
-    "string": "{}<code>{}</code> is not a string. Check that the value {} has quotes at the start and end. Escape any quotes in the value with <code>\</code>",  # noqa
-    "integer": "{}<code>{}</code> is not a integer. Check that the value {} doesn’t contain decimal points or any characters other than 0-9. Integer values should not be in quotes. ",  # noqa
-    "number": "{}<code>{}</code> is not a number. Check that the value {} doesn’t contain any characters other than 0-9 and dot (<code>.</code>). Number values should not be in quotes. ",  # noqa
+    "string": "{}<code>{}</code> is not a string. Check that the value {} has quotes at the start and end. Escape any quotes in the value with <code>\</code>",
+    "integer": "{}<code>{}</code> is not a integer. Check that the value {} doesn’t contain decimal points or any characters other than 0-9. Integer values should not be in quotes. ",
+    "number": "{}<code>{}</code> is not a number. Check that the value {} doesn’t contain any characters other than 0-9 and dot (<code>.</code>). Number values should not be in quotes. ",
     "object": "{}<code>{}</code> is not a JSON object",
     "array": "{}<code>{}</code> is not a JSON array",
 }
@@ -649,7 +649,7 @@ def get_schema_validation_errors(
     cell_src_map,
     heading_src_map,
     extra_checkers=None,
-):  # noqa
+):
     if schema_name == "record-package-schema.json":
         pkg_schema_obj = schema_obj.get_record_pkg_schema_obj()
     else:
@@ -767,7 +767,7 @@ def get_schema_validation_errors(
                     "<code>{}</code> is missing but required within <code>{}</code>",
                     field_name,
                     parent_name,
-                )  # noqa
+                )
             else:
                 message = "'{}' is missing but required".format(field_name)
                 message_safe = format_html(
@@ -785,19 +785,19 @@ def get_schema_validation_errors(
                 "<code>{}</code> does not match the regex <code>{}</code>",
                 header,
                 e.validator_value,
-            )  # noqa
+            )
 
         if e.validator == "minItems" and e.validator_value == 1:
             message_safe = format_html(
                 "<code>{}</code> is too short. You must supply at least one value, or remove the item entirely (unless it’s required).",
                 e.instance,
-            )  # noqa
+            )
 
         if e.validator == "minLength" and e.validator_value == 1:
             message_safe = format_html(
                 '<code>"{}"</code> is too short. Strings must be at least one character. This error typically indicates a missing value.',
                 e.instance,
-            )  # noqa
+            )
 
         if message_safe is None:
             message_safe = escape(message)

--- a/libcove/lib/converters.py
+++ b/libcove/lib/converters.py
@@ -78,7 +78,7 @@ def convert_spreadsheet(
         "input_format": file_type,
         "default_configuration": "RootListPath {}".format(
             lib_cove_config.config["root_list_path"]
-        ),  # noqa
+        ),
         "encoding": encoding,
         "cell_source_map": cell_source_map_path,
         "heading_source_map": heading_source_map_path,
@@ -97,7 +97,7 @@ def convert_spreadsheet(
         flattentool_options["xml"] = True
         flattentool_options["default_configuration"] += ",IDName {}".format(
             lib_cove_config.config.get("id_name", "id")
-        )  # noqa
+        )
         flattentool_options["xml_schemas"] = xml_schemas
         if lib_cove_config.config["flatten_tool"].get("xml_comment"):
             flattentool_options["xml_comment"] = lib_cove_config.config[
@@ -229,9 +229,7 @@ def convert_json(
                     flattentool.flatten(file_name, **flatten_kwargs)
                     context[
                         "conversion_warning_messages_titles"
-                    ] = filter_conversion_warnings(
-                        conversion_warnings_titles
-                    )  # noqa
+                    ] = filter_conversion_warnings(conversion_warnings_titles)
                     with open(conversion_warning_cache_path_titles, "w+") as fp:
                         json.dump(context["conversion_warning_messages_titles"], fp)
                 elif os.path.exists(conversion_warning_cache_path_titles):
@@ -252,7 +250,7 @@ def convert_json(
                     "We think you tried to upload a JSON file, but it is not well formed JSON.\n\nError message: {}".format(
                         err
                     )
-                ),  # noqa
+                ),
             }
         )
     except Exception as err:

--- a/libcove/lib/converters.py
+++ b/libcove/lib/converters.py
@@ -22,112 +22,156 @@ def filter_conversion_warnings(conversion_warnings):
 
 
 @cove_spreadsheet_conversion_error
-def convert_spreadsheet(upload_dir, upload_url, file_name, file_type, lib_cove_config,
-                        schema_url=None, pkg_schema_url=None,
-                        metatab_name='Meta', replace=False, xml=False, xml_schemas=None, cache=True):
+def convert_spreadsheet(
+    upload_dir,
+    upload_url,
+    file_name,
+    file_type,
+    lib_cove_config,
+    schema_url=None,
+    pkg_schema_url=None,
+    metatab_name="Meta",
+    replace=False,
+    xml=False,
+    xml_schemas=None,
+    cache=True,
+):
     context = {}
     if xml:
-        output_file = 'unflattened.xml'
-        converted_path = os.path.join(upload_dir, 'unflattened.xml')
+        output_file = "unflattened.xml"
+        converted_path = os.path.join(upload_dir, "unflattened.xml")
     else:
-        output_file = 'unflattened.json'
-        converted_path = os.path.join(upload_dir, 'unflattened.json')
-    cell_source_map_path = os.path.join(upload_dir, 'cell_source_map.json')
-    heading_source_map_path = os.path.join(upload_dir, 'heading_source_map.json')
-    encoding = 'utf-8-sig'
+        output_file = "unflattened.json"
+        converted_path = os.path.join(upload_dir, "unflattened.json")
+    cell_source_map_path = os.path.join(upload_dir, "cell_source_map.json")
+    heading_source_map_path = os.path.join(upload_dir, "heading_source_map.json")
+    encoding = "utf-8-sig"
 
-    if file_type == 'csv':
+    if file_type == "csv":
         # flatten-tool expects a directory full of CSVs with file names
         # matching what xlsx titles would be.
         # If only one upload file is specified, we rename it and move into
         # a new directory, such that it fits this pattern.
-        input_name = os.path.join(upload_dir, 'csv_dir')
+        input_name = os.path.join(upload_dir, "csv_dir")
         os.makedirs(input_name, exist_ok=True)
-        destination = os.path.join(input_name, lib_cove_config.config['root_list_path'] + '.csv')
+        destination = os.path.join(
+            input_name, lib_cove_config.config["root_list_path"] + ".csv"
+        )
         shutil.copy(file_name, destination)
         try:
-            with open(destination, encoding='utf-8-sig') as main_sheet_file:
+            with open(destination, encoding="utf-8-sig") as main_sheet_file:
                 main_sheet_file.read()
         except UnicodeDecodeError:
             try:
-                with open(destination, encoding='cp1252') as main_sheet_file:
+                with open(destination, encoding="cp1252") as main_sheet_file:
                     main_sheet_file.read()
-                encoding = 'cp1252'
+                encoding = "cp1252"
             except UnicodeDecodeError:
-                encoding = 'latin_1'
+                encoding = "latin_1"
     else:
         input_name = file_name
 
     flattentool_options = {
-        'output_name': converted_path,
-        'input_format': file_type,
-        'default_configuration': 'RootListPath {}'.format(lib_cove_config.config['root_list_path']), # noqa
-        'encoding': encoding,
-        'cell_source_map': cell_source_map_path,
-        'heading_source_map': heading_source_map_path,
-        'metatab_schema': pkg_schema_url,
-        'metatab_name': metatab_name,
-        'metatab_vertical_orientation': True,
-        'disable_local_refs': lib_cove_config.config['flatten_tool']['disable_local_refs'],
+        "output_name": converted_path,
+        "input_format": file_type,
+        "default_configuration": "RootListPath {}".format(
+            lib_cove_config.config["root_list_path"]
+        ),  # noqa
+        "encoding": encoding,
+        "cell_source_map": cell_source_map_path,
+        "heading_source_map": heading_source_map_path,
+        "metatab_schema": pkg_schema_url,
+        "metatab_name": metatab_name,
+        "metatab_vertical_orientation": True,
+        "disable_local_refs": lib_cove_config.config["flatten_tool"][
+            "disable_local_refs"
+        ],
     }
 
-    if lib_cove_config.config.get('hashcomments'):
-        flattentool_options['default_configuration'] += ',hashcomments'
+    if lib_cove_config.config.get("hashcomments"):
+        flattentool_options["default_configuration"] += ",hashcomments"
 
     if xml:
-        flattentool_options['xml'] = True
-        flattentool_options['default_configuration'] += ',IDName {}'.format(lib_cove_config.config.get('id_name', 'id')) # noqa
-        flattentool_options['xml_schemas'] = xml_schemas
-        if lib_cove_config.config['flatten_tool'].get('xml_comment'):
-            flattentool_options['xml_comment'] = lib_cove_config.config['flatten_tool'].get('xml_comment')
+        flattentool_options["xml"] = True
+        flattentool_options["default_configuration"] += ",IDName {}".format(
+            lib_cove_config.config.get("id_name", "id")
+        )  # noqa
+        flattentool_options["xml_schemas"] = xml_schemas
+        if lib_cove_config.config["flatten_tool"].get("xml_comment"):
+            flattentool_options["xml_comment"] = lib_cove_config.config[
+                "flatten_tool"
+            ].get("xml_comment")
 
     else:
-        flattentool_options.update({
-            'schema': schema_url,
-            'convert_titles': True,
-            'root_id': lib_cove_config.config['root_id'],
-            'root_is_list': lib_cove_config.config.get('root_is_list', False),
-            'id_name': lib_cove_config.config.get('id_name', None),
-        })
+        flattentool_options.update(
+            {
+                "schema": schema_url,
+                "convert_titles": True,
+                "root_id": lib_cove_config.config["root_id"],
+                "root_is_list": lib_cove_config.config.get("root_is_list", False),
+                "id_name": lib_cove_config.config.get("id_name", None),
+            }
+        )
 
-    conversion_warning_cache_path = os.path.join(upload_dir, 'conversion_warning_messages.json')
-    if not os.path.exists(converted_path) or not os.path.exists(cell_source_map_path) or replace:
+    conversion_warning_cache_path = os.path.join(
+        upload_dir, "conversion_warning_messages.json"
+    )
+    if (
+        not os.path.exists(converted_path)
+        or not os.path.exists(cell_source_map_path)
+        or replace
+    ):
         with warnings.catch_warnings(record=True) as conversion_warnings:
-            flattentool.unflatten(
-                input_name,
-                **flattentool_options
+            flattentool.unflatten(input_name, **flattentool_options)
+            context["conversion_warning_messages"] = filter_conversion_warnings(
+                conversion_warnings
             )
-            context['conversion_warning_messages'] = filter_conversion_warnings(conversion_warnings)
 
         if cache:
-            with open(conversion_warning_cache_path, 'w+') as fp:
-                json.dump(context['conversion_warning_messages'], fp)
+            with open(conversion_warning_cache_path, "w+") as fp:
+                json.dump(context["conversion_warning_messages"], fp)
 
     elif os.path.exists(conversion_warning_cache_path):
         with open(conversion_warning_cache_path) as fp:
-            context['conversion_warning_messages'] = json.load(fp)
+            context["conversion_warning_messages"] = json.load(fp)
 
-    context['converted_file_size'] = os.path.getsize(converted_path)
+    context["converted_file_size"] = os.path.getsize(converted_path)
 
-    context.update({
-        'conversion': 'unflatten',
-        'converted_path': converted_path,
-        'converted_url': '{}{}{}'.format(upload_url, '' if upload_url.endswith('/') else '/', output_file),
-        "csv_encoding": encoding
-    })
+    context.update(
+        {
+            "conversion": "unflatten",
+            "converted_path": converted_path,
+            "converted_url": "{}{}{}".format(
+                upload_url, "" if upload_url.endswith("/") else "/", output_file
+            ),
+            "csv_encoding": encoding,
+        }
+    )
     return context
 
 
-def convert_json(upload_dir, upload_url, file_name, lib_cove_config, root_list_path=None, root_id=None,
-                 schema_url=None, replace=False, request=None, flatten=False, cache=True, xml=False):
+def convert_json(
+    upload_dir,
+    upload_url,
+    file_name,
+    lib_cove_config,
+    root_list_path=None,
+    root_id=None,
+    schema_url=None,
+    replace=False,
+    request=None,
+    flatten=False,
+    cache=True,
+    xml=False,
+):
     context = {}
-    converted_path = os.path.join(upload_dir, 'flattened')
+    converted_path = os.path.join(upload_dir, "flattened")
 
     if root_list_path is None:
-        root_list_path = lib_cove_config.config['root_list_path']
+        root_list_path = lib_cove_config.config["root_list_path"]
 
     if root_id is None:
-        root_id = lib_cove_config.config['root_id']
+        root_id = lib_cove_config.config["root_id"]
 
     flatten_kwargs = dict(
         output_name=converted_path,
@@ -135,72 +179,90 @@ def convert_json(upload_dir, upload_url, file_name, lib_cove_config, root_list_p
         root_list_path=root_list_path,
         root_id=root_id,
         schema=schema_url,
-        disable_local_refs=lib_cove_config.config['flatten_tool']['disable_local_refs'],
-        remove_empty_schema_columns=lib_cove_config.config['flatten_tool']['remove_empty_schema_columns'],
-        root_is_list=lib_cove_config.config.get('root_is_list', False),
+        disable_local_refs=lib_cove_config.config["flatten_tool"]["disable_local_refs"],
+        remove_empty_schema_columns=lib_cove_config.config["flatten_tool"][
+            "remove_empty_schema_columns"
+        ],
+        root_is_list=lib_cove_config.config.get("root_is_list", False),
     )
 
     if xml:
-        flatten_kwargs['xml'] = True
-        flatten_kwargs['id_name'] = lib_cove_config.config.get('id_name', 'id')
+        flatten_kwargs["xml"] = True
+        flatten_kwargs["id_name"] = lib_cove_config.config.get("id_name", "id")
 
     try:
-        conversion_warning_cache_path = os.path.join(upload_dir, 'conversion_warning_messages.json')
-        conversion_exists = os.path.exists(converted_path + '.xlsx')
+        conversion_warning_cache_path = os.path.join(
+            upload_dir, "conversion_warning_messages.json"
+        )
+        conversion_exists = os.path.exists(converted_path + ".xlsx")
         if not conversion_exists or replace:
             with warnings.catch_warnings(record=True) as conversion_warnings:
                 if flatten or (replace and conversion_exists):
                     flattentool.flatten(file_name, **flatten_kwargs)
                 else:
-                    return {'conversion': 'flattenable'}
-                context['conversion_warning_messages'] = filter_conversion_warnings(conversion_warnings)
+                    return {"conversion": "flattenable"}
+                context["conversion_warning_messages"] = filter_conversion_warnings(
+                    conversion_warnings
+                )
 
             if cache:
-                with open(conversion_warning_cache_path, 'w+') as fp:
-                    json.dump(context['conversion_warning_messages'], fp)
+                with open(conversion_warning_cache_path, "w+") as fp:
+                    json.dump(context["conversion_warning_messages"], fp)
 
         elif os.path.exists(conversion_warning_cache_path):
             with open(conversion_warning_cache_path) as fp:
-                context['conversion_warning_messages'] = json.load(fp)
+                context["conversion_warning_messages"] = json.load(fp)
 
-        context['converted_file_size'] = os.path.getsize(converted_path + '.xlsx')
-        conversion_warning_cache_path_titles = os.path.join(upload_dir, 'conversion_warning_messages_titles.json')
+        context["converted_file_size"] = os.path.getsize(converted_path + ".xlsx")
+        conversion_warning_cache_path_titles = os.path.join(
+            upload_dir, "conversion_warning_messages_titles.json"
+        )
 
-        if lib_cove_config.config['convert_titles']:
+        if lib_cove_config.config["convert_titles"]:
             with warnings.catch_warnings(record=True) as conversion_warnings_titles:
-                flatten_kwargs.update(dict(
-                    output_name=converted_path + '-titles',
-                    use_titles=True
-                ))
-                if not os.path.exists(converted_path + '-titles.xlsx') or replace:
+                flatten_kwargs.update(
+                    dict(output_name=converted_path + "-titles", use_titles=True)
+                )
+                if not os.path.exists(converted_path + "-titles.xlsx") or replace:
                     flattentool.flatten(file_name, **flatten_kwargs)
-                    context['conversion_warning_messages_titles'] = filter_conversion_warnings(conversion_warnings_titles) # noqa
-                    with open(conversion_warning_cache_path_titles, 'w+') as fp:
-                        json.dump(context['conversion_warning_messages_titles'], fp)
+                    context[
+                        "conversion_warning_messages_titles"
+                    ] = filter_conversion_warnings(
+                        conversion_warnings_titles
+                    )  # noqa
+                    with open(conversion_warning_cache_path_titles, "w+") as fp:
+                        json.dump(context["conversion_warning_messages_titles"], fp)
                 elif os.path.exists(conversion_warning_cache_path_titles):
                     with open(conversion_warning_cache_path_titles) as fp:
-                        context['conversion_warning_messages_titles'] = json.load(fp)
+                        context["conversion_warning_messages_titles"] = json.load(fp)
 
-            context['converted_file_size_titles'] = os.path.getsize(converted_path + '-titles.xlsx')
+            context["converted_file_size_titles"] = os.path.getsize(
+                converted_path + "-titles.xlsx"
+            )
 
     except BadlyFormedJSONError as err:
-        raise CoveInputDataError(context={
-            'sub_title': _("Sorry, we can't process that data"),
-            'link': 'index',
-            'link_text': _('Try Again'),
-            'msg': _('We think you tried to upload a JSON file, but it is not well formed JSON.\n\nError message: {}'.format(err)) # noqa
-        })
+        raise CoveInputDataError(
+            context={
+                "sub_title": _("Sorry, we can't process that data"),
+                "link": "index",
+                "link_text": _("Try Again"),
+                "msg": _(
+                    "We think you tried to upload a JSON file, but it is not well formed JSON.\n\nError message: {}".format(
+                        err
+                    )
+                ),  # noqa
+            }
+        )
     except Exception as err:
-        logger.exception(err, extra={
-            'request': request,
-            })
-        return {
-            'conversion': 'flatten',
-            'conversion_error': repr(err)
+        logger.exception(err, extra={"request": request})
+        return {"conversion": "flatten", "conversion_error": repr(err)}
+    context.update(
+        {
+            "conversion": "flatten",
+            "converted_path": converted_path,
+            "converted_url": "{}{}flattened".format(
+                upload_url, "" if upload_url.endswith("/") else "/"
+            ),
         }
-    context.update({
-        'conversion': 'flatten',
-        'converted_path': converted_path,
-        'converted_url': '{}{}flattened'.format(upload_url, '' if upload_url.endswith('/') else '/')
-    })
+    )
     return context

--- a/libcove/lib/converters.py
+++ b/libcove/lib/converters.py
@@ -1,12 +1,14 @@
+import json
+import logging
 import os
 import shutil
-import json
 import warnings
-import logging
+
 import flattentool
-from flattentool.json_input import BadlyFormedJSONError
-from .exceptions import cove_spreadsheet_conversion_error, CoveInputDataError
 from django.utils.translation import ugettext_lazy as _
+from flattentool.json_input import BadlyFormedJSONError
+
+from .exceptions import CoveInputDataError, cove_spreadsheet_conversion_error
 
 logger = logging.getLogger(__name__)
 

--- a/libcove/lib/exceptions.py
+++ b/libcove/lib/exceptions.py
@@ -1,7 +1,7 @@
 import functools
 import logging
-from django.utils.translation import ugettext_lazy as _
 
+from django.utils.translation import ugettext_lazy as _
 
 logger = logging.getLogger(__name__)
 

--- a/libcove/lib/exceptions.py
+++ b/libcove/lib/exceptions.py
@@ -11,6 +11,7 @@ class CoveInputDataError(Exception):
     An error that we think is due to the data input by the user, rather than a
     bug in the application.
     """
+
     def __init__(self, context=None):
         if context:
             self.context = context
@@ -18,10 +19,12 @@ class CoveInputDataError(Exception):
 
 class UnrecognisedFileType(CoveInputDataError):
     context = {
-        'sub_title': _("Sorry, we can't process that data"),
-        'link': 'index',
-        'link_text': _('Try Again'),
-        'msg': _('We did not recognise the file type.\n\nWe can only process json, csv and xlsx files.')
+        "sub_title": _("Sorry, we can't process that data"),
+        "link": "index",
+        "link_text": _("Try Again"),
+        "msg": _(
+            "We did not recognise the file type.\n\nWe can only process json, csv and xlsx files."
+        ),
     }
 
 
@@ -31,14 +34,17 @@ def cove_spreadsheet_conversion_error(func):
         try:
             return func(request, *args, **kwargs)
         except Exception as err:
-            logger.exception(err, extra={
-                'request': request,
-                })
-            raise CoveInputDataError({
-                'sub_title': _("Sorry, we can't process that data"),
-                'link': 'index',
-                'link_text': _('Try Again'),
-                'msg': _('We think you tried to supply a spreadsheet, but we failed to convert it.'
-                         '\n\nError message: {}'.format(repr(err)))
-            })
+            logger.exception(err, extra={"request": request})
+            raise CoveInputDataError(
+                {
+                    "sub_title": _("Sorry, we can't process that data"),
+                    "link": "index",
+                    "link_text": _("Try Again"),
+                    "msg": _(
+                        "We think you tried to supply a spreadsheet, but we failed to convert it."
+                        "\n\nError message: {}".format(repr(err))
+                    ),
+                }
+            )
+
     return wrapper

--- a/libcove/lib/tools.py
+++ b/libcove/lib/tools.py
@@ -10,7 +10,11 @@ def cached_get_request(url):
 
 
 def get_request(url, config=None, force_cache=False):
-    if force_cache or (config and 'cache_all_requests' in config.config and config.config['cache_all_requests']):
+    if force_cache or (
+        config
+        and "cache_all_requests" in config.config
+        and config.config["cache_all_requests"]
+    ):
         return cached_get_request(url)
     else:
         return requests.get(url)
@@ -26,6 +30,7 @@ def ignore_errors(f):
                 return return_on_error
         else:
             return f(json_data, *args, **kwargs)
+
     return ignore
 
 
@@ -68,7 +73,7 @@ def get_no_exception(item, key, fallback):
 
 def update_docs(document_parent, counter):
     count = 0
-    documents = document_parent.get('documents', [])
+    documents = document_parent.get("documents", [])
     for document in documents:
         count += 1
         doc_type = document.get("documentType")
@@ -81,21 +86,21 @@ def get_file_type(file_name):
     """ Takes an filename (type string), and returns a string saying what type it is."""
     # Older versions of this could take DJango objects to.
     # Tho we don't really want to support that, put in a check for that.
-    if not isinstance(file_name, str) and hasattr(file_name, 'path'):
+    if not isinstance(file_name, str) and hasattr(file_name, "path"):
         file_name = file_name.path
     # First, just check the extension on the file name
-    if file_name.lower().endswith('.json'):
-        return 'json'
-    if file_name.lower().endswith('.xlsx'):
-        return 'xlsx'
-    if file_name.lower().endswith('.csv'):
-        return 'csv'
+    if file_name.lower().endswith(".json"):
+        return "json"
+    if file_name.lower().endswith(".xlsx"):
+        return "xlsx"
+    if file_name.lower().endswith(".csv"):
+        return "csv"
     # Try and load the first bit of the file to see if it's JSON?
     try:
-        with open(file_name, 'rb') as fp:
+        with open(file_name, "rb") as fp:
             first_byte = fp.read(1)
-            if first_byte in [b'{', b'[']:
-                return 'json'
+            if first_byte in [b"{", b"["]:
+                return "json"
     except FileNotFoundError:
         pass
     # All right, we give up.

--- a/libcove/lib/tools.py
+++ b/libcove/lib/tools.py
@@ -1,6 +1,8 @@
-from functools import lru_cache, wraps
 from decimal import Decimal
+from functools import lru_cache, wraps
+
 import requests
+
 from .exceptions import UnrecognisedFileType
 
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,4 @@
 -e .
 pytest
 flake8
+isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [flake8]
-max-line-length=119
+# Ignore style checking, because black does this for us
+ignore = E,W

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="libcove",

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,26 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='libcove',
-    version='0.11.0',
-    author='Open Data Services',
-    author_email='code@opendataservices.coop',
-    url='https://github.com/OpenDataServices/lib-cove',
-    description='A data review library',
+    name="libcove",
+    version="0.11.0",
+    author="Open Data Services",
+    author_email="code@opendataservices.coop",
+    url="https://github.com/OpenDataServices/lib-cove",
+    description="A data review library",
     packages=find_packages(),
-    long_description='A data review library',
+    long_description="A data review library",
     install_requires=[
-        'jsonref',
-        'jsonschema',
-        'CommonMark',
-        'Django',
-        'bleach',
-        'requests',
-        'json-merge-patch',
-        'cached-property',
+        "jsonref",
+        "jsonschema",
+        "CommonMark",
+        "Django",
+        "bleach",
+        "requests",
+        "json-merge-patch",
+        "cached-property",
         # TODO Should also have flatten-tool >= v0.5.0 - that is currently in requirements instead.
     ],
     classifiers=[
-            'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
-    ]
+        "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)"
+    ],
 )

--- a/tests/lib/test_common.py
+++ b/tests/lib/test_common.py
@@ -24,7 +24,7 @@ def test_get_json_data_deprecated_fields():
             "common",
             "tenders_releases_2_releases_with_deprecated_fields.json",
         )
-    ) as fp:  # noqa
+    ) as fp:
         json_data_w_deprecations = json.load(fp)
 
     schema_obj = SchemaJsonMixin()
@@ -135,7 +135,7 @@ def test_fields_present_10():
         "/a/c_1": 1,
         "/a/c_1/d": 2,
         "/b_1": 1,
-    }  # noqa
+    }
 
 
 def test_get_schema_deprecated_paths():
@@ -187,7 +187,7 @@ def test_schema_dict_fields_generator_release_schema_deprecated_fields():
             "common",
             "release_schema_deprecated_fields.json",
         )
-    ) as fp:  # noqa
+    ) as fp:
         json_schema = json.load(fp)
 
     data = sorted(set(schema_dict_fields_generator(json_schema)))
@@ -216,7 +216,7 @@ def test_schema_dict_fields_generator_schema_with_list_and_oneof():
             "common",
             "schema_with_list_and_oneof.json",
         )
-    ) as fp:  # noqa
+    ) as fp:
         json_schema = json.load(fp)
 
     data = sorted(set(schema_dict_fields_generator(json_schema)))
@@ -250,7 +250,7 @@ def test_fields_present_generator_tenders_releases_2_releases():
             "common",
             "tenders_releases_2_releases.json",
         )
-    ) as fp:  # noqa
+    ) as fp:
         json_schema = json.load(fp)
 
     data = sorted(set(key for key, _ in fields_present_generator(json_schema)))
@@ -303,7 +303,7 @@ def test_fields_present_generator_data_root_is_list():
             "common",
             "data_root_is_list.json",
         )
-    ) as fp:  # noqa
+    ) as fp:
         json_schema = json.load(fp)
 
     data = sorted(set(key for key, _ in fields_present_generator(json_schema)))

--- a/tests/lib/test_common.py
+++ b/tests/lib/test_common.py
@@ -526,12 +526,8 @@ def test_validation_invalid_record_package():
         },
         {
             "error_id": "releases_both_embedded_and_linked",
-            "message": "This array should contain either entirely embedded releases or linked releases. "
-            "Embedded releases contain an 'id' whereas linked releases do not. "
-            "Your releases contain a mixture.",
-            "message_safe": "This array should contain either entirely embedded releases or linked releases. "
-            "Embedded releases contain an &#39;id&#39; whereas linked releases do not. "
-            "Your releases contain a mixture.",
+            "message": "This array should contain either entirely embedded releases or linked releases. Embedded releases contain an 'id' whereas linked releases do not. Your releases contain a mixture.",
+            "message_safe": "This array should contain either entirely embedded releases or linked releases. Embedded releases contain an &#39;id&#39; whereas linked releases do not. Your releases contain a mixture.",
             "validator": "oneOf",
             "assumption": None,
             "message_type": "oneOf",
@@ -544,8 +540,7 @@ def test_validation_invalid_record_package():
         {
             "error_id": None,
             "message": "[] is too short",
-            "message_safe": "<code>[]</code> is too short. "
-            "You must supply at least one value, or remove the item entirely (unless it’s required).",
+            "message_safe": "<code>[]</code> is too short. You must supply at least one value, or remove the item entirely (unless it’s required).",
             "validator": "minItems",
             "assumption": "linked_releases",
             "message_type": "minItems",

--- a/tests/lib/test_common.py
+++ b/tests/lib/test_common.py
@@ -1,17 +1,18 @@
 import json
 import os
 from collections import OrderedDict
+
 from libcove.lib.common import (
     SchemaJsonMixin,
-    get_json_data_generic_paths,
-    get_json_data_deprecated_fields,
-    get_fields_present,
     _get_schema_deprecated_paths,
-    schema_dict_fields_generator,
     fields_present_generator,
-    get_orgids_prefixes,
     get_additional_fields_info,
+    get_fields_present,
+    get_json_data_deprecated_fields,
+    get_json_data_generic_paths,
+    get_orgids_prefixes,
     get_schema_validation_errors,
+    schema_dict_fields_generator,
 )
 
 

--- a/tests/lib/test_common.py
+++ b/tests/lib/test_common.py
@@ -1,33 +1,76 @@
 import json
 import os
 from collections import OrderedDict
-from libcove.lib.common import SchemaJsonMixin, \
-    get_json_data_generic_paths, get_json_data_deprecated_fields, get_fields_present, \
-    _get_schema_deprecated_paths, schema_dict_fields_generator, fields_present_generator, get_orgids_prefixes, \
-    get_additional_fields_info, get_schema_validation_errors
+from libcove.lib.common import (
+    SchemaJsonMixin,
+    get_json_data_generic_paths,
+    get_json_data_deprecated_fields,
+    get_fields_present,
+    _get_schema_deprecated_paths,
+    schema_dict_fields_generator,
+    fields_present_generator,
+    get_orgids_prefixes,
+    get_additional_fields_info,
+    get_schema_validation_errors,
+)
 
 
 def test_get_json_data_deprecated_fields():
-    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtures', 'common',
-                           'tenders_releases_2_releases_with_deprecated_fields.json')) as fp:  # noqa
+    with open(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "fixtures",
+            "common",
+            "tenders_releases_2_releases_with_deprecated_fields.json",
+        )
+    ) as fp:  # noqa
         json_data_w_deprecations = json.load(fp)
 
     schema_obj = SchemaJsonMixin()
-    schema_obj.schema_host = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtures', 'common/')
-    schema_obj.release_pkg_schema_name = 'release_package_schema_ref_release_schema_deprecated_fields.json'
-    schema_obj.release_pkg_schema_url = os.path.join(schema_obj.schema_host, schema_obj.release_pkg_schema_name)
+    schema_obj.schema_host = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "fixtures", "common/"
+    )
+    schema_obj.release_pkg_schema_name = (
+        "release_package_schema_ref_release_schema_deprecated_fields.json"
+    )
+    schema_obj.release_pkg_schema_url = os.path.join(
+        schema_obj.schema_host, schema_obj.release_pkg_schema_name
+    )
     json_data_paths = get_json_data_generic_paths(json_data_w_deprecations)
-    deprecated_data_fields = get_json_data_deprecated_fields(json_data_paths, schema_obj)
-    expected_result = OrderedDict([
-        ('initiationType', {"paths": ('releases/0', 'releases/1'),
-                            "explanation": ('1.1', 'Not a useful field as always has to be tender')}),
-        ('quantity', {"paths": ('releases/0/tender/items/0',),
-                      "explanation": ('1.1', 'Nobody cares about quantities')})
-    ])
+    deprecated_data_fields = get_json_data_deprecated_fields(
+        json_data_paths, schema_obj
+    )
+    expected_result = OrderedDict(
+        [
+            (
+                "initiationType",
+                {
+                    "paths": ("releases/0", "releases/1"),
+                    "explanation": (
+                        "1.1",
+                        "Not a useful field as always has to be tender",
+                    ),
+                },
+            ),
+            (
+                "quantity",
+                {
+                    "paths": ("releases/0/tender/items/0",),
+                    "explanation": ("1.1", "Nobody cares about quantities"),
+                },
+            ),
+        ]
+    )
     for field_name in expected_result.keys():
         assert field_name in deprecated_data_fields
-        assert expected_result[field_name]["paths"] == deprecated_data_fields[field_name]["paths"]
-        assert expected_result[field_name]["explanation"] == deprecated_data_fields[field_name]["explanation"]
+        assert (
+            expected_result[field_name]["paths"]
+            == deprecated_data_fields[field_name]["paths"]
+        )
+        assert (
+            expected_result[field_name]["explanation"]
+            == deprecated_data_fields[field_name]["explanation"]
+        )
 
 
 def test_fields_present_1():
@@ -35,54 +78,99 @@ def test_fields_present_1():
 
 
 def test_fields_present_2():
-    assert get_fields_present({'a': 1, 'b': 2}) == {"/a": 1, "/b": 1}
+    assert get_fields_present({"a": 1, "b": 2}) == {"/a": 1, "/b": 1}
 
 
 def test_fields_present_3():
-    assert get_fields_present({'a': {}, 'b': 2}) == {'/a': 1, '/b': 1}
+    assert get_fields_present({"a": {}, "b": 2}) == {"/a": 1, "/b": 1}
 
 
 def test_fields_present_4():
-    assert get_fields_present({'a': {'c': 1}, 'b': 2}) == {'/a': 1, '/b': 1, '/a/c': 1}
+    assert get_fields_present({"a": {"c": 1}, "b": 2}) == {"/a": 1, "/b": 1, "/a/c": 1}
 
 
 def test_fields_present_5():
-    assert get_fields_present({'a': {'c': 1}, 'b': 2}) == {'/a': 1, '/b': 1, '/a/c': 1}
+    assert get_fields_present({"a": {"c": 1}, "b": 2}) == {"/a": 1, "/b": 1, "/a/c": 1}
 
 
 def test_fields_present_6():
-    assert get_fields_present({'a': {'c': {'d': 1}}, 'b': 2}) == {'/a': 1, '/b': 1, '/a/c': 1, '/a/c/d': 1}
+    assert get_fields_present({"a": {"c": {"d": 1}}, "b": 2}) == {
+        "/a": 1,
+        "/b": 1,
+        "/a/c": 1,
+        "/a/c/d": 1,
+    }
 
 
 def test_fields_present_7():
-    assert get_fields_present({'a': [{'c': 1}], 'b': 2}) == {'/a': 1, '/b': 1, '/a/c': 1}
+    assert get_fields_present({"a": [{"c": 1}], "b": 2}) == {
+        "/a": 1,
+        "/b": 1,
+        "/a/c": 1,
+    }
 
 
 def test_fields_present_8():
-    assert get_fields_present({'a': {'c': [{'d': 1}]}, 'b': 2}) == {'/a': 1, '/b': 1, '/a/c': 1, '/a/c/d': 1}
+    assert get_fields_present({"a": {"c": [{"d": 1}]}, "b": 2}) == {
+        "/a": 1,
+        "/b": 1,
+        "/a/c": 1,
+        "/a/c/d": 1,
+    }
 
 
 def test_fields_present_9():
-    assert get_fields_present({'a': {'c_1': [{'d': 1}]}, 'b_1': 2}) == {'/a': 1, '/a/c_1': 1, '/a/c_1/d': 1, '/b_1': 1}
+    assert get_fields_present({"a": {"c_1": [{"d": 1}]}, "b_1": 2}) == {
+        "/a": 1,
+        "/a/c_1": 1,
+        "/a/c_1/d": 1,
+        "/b_1": 1,
+    }
 
 
 def test_fields_present_10():
-    assert get_fields_present({'a': {'c_1': [{'d': 1}, {'d': 1}]}, 'b_1': 2}) == {'/a': 1, '/a/c_1': 1, '/a/c_1/d': 2, '/b_1': 1} # noqa
+    assert get_fields_present({"a": {"c_1": [{"d": 1}, {"d": 1}]}, "b_1": 2}) == {
+        "/a": 1,
+        "/a/c_1": 1,
+        "/a/c_1/d": 2,
+        "/b_1": 1,
+    }  # noqa
 
 
 def test_get_schema_deprecated_paths():
     schema_obj = SchemaJsonMixin()
-    schema_obj.schema_host = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtures', 'common/')
-    schema_obj.release_pkg_schema_name = 'release_package_schema_ref_release_schema_deprecated_fields.json'
-    schema_obj.release_pkg_schema_url = os.path.join(schema_obj.schema_host, schema_obj.release_pkg_schema_name)
+    schema_obj.schema_host = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "fixtures", "common/"
+    )
+    schema_obj.release_pkg_schema_name = (
+        "release_package_schema_ref_release_schema_deprecated_fields.json"
+    )
+    schema_obj.release_pkg_schema_url = os.path.join(
+        schema_obj.schema_host, schema_obj.release_pkg_schema_name
+    )
     deprecated_paths = _get_schema_deprecated_paths(schema_obj)
     expected_results = [
-        (('releases', 'initiationType'), ('1.1', 'Not a useful field as always has to be tender')),
-        (('releases', 'planning',), ('1.1', "Testing deprecation for objects with '$ref'")),
-        (('releases', 'tender', 'hasEnquiries'), ('1.1', 'Deprecated just for fun')),
-        (('releases', 'contracts', 'items', 'quantity'), ('1.1', 'Nobody cares about quantities')),
-        (('releases', 'tender', 'items', 'quantity'), ('1.1', 'Nobody cares about quantities')),
-        (('releases', 'awards', 'items', 'quantity'), ('1.1', 'Nobody cares about quantities'))
+        (
+            ("releases", "initiationType"),
+            ("1.1", "Not a useful field as always has to be tender"),
+        ),
+        (
+            ("releases", "planning"),
+            ("1.1", "Testing deprecation for objects with '$ref'"),
+        ),
+        (("releases", "tender", "hasEnquiries"), ("1.1", "Deprecated just for fun")),
+        (
+            ("releases", "contracts", "items", "quantity"),
+            ("1.1", "Nobody cares about quantities"),
+        ),
+        (
+            ("releases", "tender", "items", "quantity"),
+            ("1.1", "Nobody cares about quantities"),
+        ),
+        (
+            ("releases", "awards", "items", "quantity"),
+            ("1.1", "Nobody cares about quantities"),
+        ),
     ]
     assert len(deprecated_paths) == 6
     for path in expected_results:
@@ -91,83 +179,170 @@ def test_get_schema_deprecated_paths():
 
 def test_schema_dict_fields_generator_release_schema_deprecated_fields():
 
-    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtures', 'common',
-                           'release_schema_deprecated_fields.json')) as fp:  # noqa
+    with open(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "fixtures",
+            "common",
+            "release_schema_deprecated_fields.json",
+        )
+    ) as fp:  # noqa
         json_schema = json.load(fp)
 
     data = sorted(set(schema_dict_fields_generator(json_schema)))
 
     assert 11 == len(data)
 
-    assert data[0] == '/awards'
-    assert data[1] == '/buyer'
-    assert data[2] == '/contracts'
-    assert data[3] == '/date'
-    assert data[4] == '/id'
-    assert data[5] == '/initiationType'
-    assert data[6] == '/language'
-    assert data[7] == '/ocid'
-    assert data[8] == '/planning'
-    assert data[9] == '/tag'
-    assert data[10] == '/tender'
+    assert data[0] == "/awards"
+    assert data[1] == "/buyer"
+    assert data[2] == "/contracts"
+    assert data[3] == "/date"
+    assert data[4] == "/id"
+    assert data[5] == "/initiationType"
+    assert data[6] == "/language"
+    assert data[7] == "/ocid"
+    assert data[8] == "/planning"
+    assert data[9] == "/tag"
+    assert data[10] == "/tender"
 
 
 def test_schema_dict_fields_generator_schema_with_list_and_oneof():
 
-    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtures', 'common',
-                           'schema_with_list_and_oneof.json')) as fp:  # noqa
+    with open(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "fixtures",
+            "common",
+            "schema_with_list_and_oneof.json",
+        )
+    ) as fp:  # noqa
         json_schema = json.load(fp)
 
     data = sorted(set(schema_dict_fields_generator(json_schema)))
 
-    assert data == ['/dissolutionDate', '/entityType', '/names', '/names/familyName', '/names/fullName',
-                    '/names/givenName', '/names/patronymicName', '/names/type', '/source', '/source/assertedBy',
-                    '/source/assertedBy/name', '/source/assertedBy/uri', '/source/description', '/source/retrievedAt',
-                    '/source/type', '/source/url']
+    assert data == [
+        "/dissolutionDate",
+        "/entityType",
+        "/names",
+        "/names/familyName",
+        "/names/fullName",
+        "/names/givenName",
+        "/names/patronymicName",
+        "/names/type",
+        "/source",
+        "/source/assertedBy",
+        "/source/assertedBy/name",
+        "/source/assertedBy/uri",
+        "/source/description",
+        "/source/retrievedAt",
+        "/source/type",
+        "/source/url",
+    ]
 
 
 def test_fields_present_generator_tenders_releases_2_releases():
 
-    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtures', 'common',
-                           'tenders_releases_2_releases.json')) as fp:  # noqa
+    with open(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "fixtures",
+            "common",
+            "tenders_releases_2_releases.json",
+        )
+    ) as fp:  # noqa
         json_schema = json.load(fp)
 
     data = sorted(set(key for key, _ in fields_present_generator(json_schema)))
 
-    assert data == ['/license', '/publishedDate', '/publisher', '/publisher/name', '/publisher/scheme',
-                    '/publisher/uid',
-                    '/publisher/uri', '/releases', '/releases/buyer', '/releases/buyer/name', '/releases/date',
-                    '/releases/id',
-                    '/releases/initiationType', '/releases/language', '/releases/ocid', '/releases/tag',
-                    '/releases/tender',
-                    '/releases/tender/awardCriteriaDetails', '/releases/tender/documents',
-                    '/releases/tender/documents/id',
-                    '/releases/tender/documents/url', '/releases/tender/id', '/releases/tender/items',
-                    '/releases/tender/items/classification', '/releases/tender/items/classification/description',
-                    '/releases/tender/items/classification/scheme', '/releases/tender/items/description',
-                    '/releases/tender/items/id',
-                    '/releases/tender/methodRationale', '/releases/tender/procuringEntity',
-                    '/releases/tender/procuringEntity/name',
-                    '/releases/tender/procuringEntity/name_fr', '/releases/tender/tenderPeriod',
-                    '/releases/tender/tenderPeriod/endDate', '/uri']
+    assert data == [
+        "/license",
+        "/publishedDate",
+        "/publisher",
+        "/publisher/name",
+        "/publisher/scheme",
+        "/publisher/uid",
+        "/publisher/uri",
+        "/releases",
+        "/releases/buyer",
+        "/releases/buyer/name",
+        "/releases/date",
+        "/releases/id",
+        "/releases/initiationType",
+        "/releases/language",
+        "/releases/ocid",
+        "/releases/tag",
+        "/releases/tender",
+        "/releases/tender/awardCriteriaDetails",
+        "/releases/tender/documents",
+        "/releases/tender/documents/id",
+        "/releases/tender/documents/url",
+        "/releases/tender/id",
+        "/releases/tender/items",
+        "/releases/tender/items/classification",
+        "/releases/tender/items/classification/description",
+        "/releases/tender/items/classification/scheme",
+        "/releases/tender/items/description",
+        "/releases/tender/items/id",
+        "/releases/tender/methodRationale",
+        "/releases/tender/procuringEntity",
+        "/releases/tender/procuringEntity/name",
+        "/releases/tender/procuringEntity/name_fr",
+        "/releases/tender/tenderPeriod",
+        "/releases/tender/tenderPeriod/endDate",
+        "/uri",
+    ]
 
 
 def test_fields_present_generator_data_root_is_list():
 
-    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtures', 'common',
-                           'data_root_is_list.json')) as fp:  # noqa
+    with open(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "fixtures",
+            "common",
+            "data_root_is_list.json",
+        )
+    ) as fp:  # noqa
         json_schema = json.load(fp)
 
     data = sorted(set(key for key, _ in fields_present_generator(json_schema)))
 
-    assert data == ['/addresses', '/addresses/address', '/addresses/country', '/addresses/postCode', '/addresses/type',
-                    '/birthDate', '/entityType', '/foundingDate', '/identifiers', '/identifiers/id',
-                    '/identifiers/scheme', '/interestedParty', '/interestedParty/describedByPersonStatement',
-                    '/interests', '/interests/beneficialOwnershipOrControl', '/interests/interestLevel',
-                    '/interests/share', '/interests/share/exact', '/interests/startDate', '/interests/type', '/name',
-                    '/names', '/names/familyName', '/names/fullName', '/names/givenName', '/names/type',
-                    '/nationalities', '/nationalities/code', '/personType', '/statementDate', '/statementID',
-                    '/statementType', '/subject', '/subject/describedByEntityStatement']
+    assert data == [
+        "/addresses",
+        "/addresses/address",
+        "/addresses/country",
+        "/addresses/postCode",
+        "/addresses/type",
+        "/birthDate",
+        "/entityType",
+        "/foundingDate",
+        "/identifiers",
+        "/identifiers/id",
+        "/identifiers/scheme",
+        "/interestedParty",
+        "/interestedParty/describedByPersonStatement",
+        "/interests",
+        "/interests/beneficialOwnershipOrControl",
+        "/interests/interestLevel",
+        "/interests/share",
+        "/interests/share/exact",
+        "/interests/startDate",
+        "/interests/type",
+        "/name",
+        "/names",
+        "/names/familyName",
+        "/names/fullName",
+        "/names/givenName",
+        "/names/type",
+        "/nationalities",
+        "/nationalities/code",
+        "/personType",
+        "/statementDate",
+        "/statementID",
+        "/statementType",
+        "/subject",
+        "/subject/describedByEntityStatement",
+    ]
 
 
 def test_get_additional_fields_info():
@@ -177,18 +352,35 @@ def test_get_additional_fields_info():
         "non_additional_list": [1, 2],
         "non_additional_object": {"z": "z"},
         "additional_object": {"a": "a", "b": "b"},
-        "additional_list": [{"c": "c", "d": "d"}, {"e": "e", "f": "f"}, {"e": "e", "f": "f"}]
+        "additional_list": [
+            {"c": "c", "d": "d"},
+            {"e": "e", "f": "f"},
+            {"e": "e", "f": "f"},
+        ],
     }
 
-    schema_fields = {"/non_additional_field", "/non_additional_list",
-                     "/non_additional_object", "/non_additional_object/z"}
+    schema_fields = {
+        "/non_additional_field",
+        "/non_additional_list",
+        "/non_additional_object",
+        "/non_additional_object/z",
+    }
 
-    additional_field_info = get_additional_fields_info(json_data=simple_data,
-                                                       schema_fields=schema_fields,
-                                                       context={})
+    additional_field_info = get_additional_fields_info(
+        json_data=simple_data, schema_fields=schema_fields, context={}
+    )
     assert len(additional_field_info) == 8
-    assert sum(info['count'] for info in additional_field_info.values()) == 10
-    assert len([info for info in additional_field_info.values() if info['root_additional_field']]) == 2
+    assert sum(info["count"] for info in additional_field_info.values()) == 10
+    assert (
+        len(
+            [
+                info
+                for info in additional_field_info.values()
+                if info["root_additional_field"]
+            ]
+        )
+        == 2
+    )
 
 
 def test_get_orgids_prefixes_live():
@@ -235,7 +427,7 @@ def test_validation_invalid_record_package():
 
     assert validation_error_jsons == [
         {
-            'error_id': None,
+            "error_id": None,
             "message": "'date' is missing but required within 'releases'",
             "message_safe": "<code>date</code> is missing but required within <code>releases</code>",
             "validator": "required",
@@ -248,7 +440,7 @@ def test_validation_invalid_record_package():
             "values": [{"path": "records/2/releases/0"}],
         },
         {
-            'error_id': None,
+            "error_id": None,
             "message": "'date' is missing but required within 'releases'",
             "message_safe": "<code>date</code> is missing but required within <code>releases</code>",
             "validator": "required",
@@ -264,7 +456,7 @@ def test_validation_invalid_record_package():
             ],
         },
         {
-            'error_id': None,
+            "error_id": None,
             "message": "'initiationType' is missing but required within 'releases'",
             "message_safe": "<code>initiationType</code> is missing but required within <code>releases</code>",
             "validator": "required",
@@ -277,7 +469,7 @@ def test_validation_invalid_record_package():
             "values": [{"path": "records/2/releases/0"}],
         },
         {
-            'error_id': None,
+            "error_id": None,
             "message": "'ocid' is missing but required within 'releases'",
             "message_safe": "<code>ocid</code> is missing but required within <code>releases</code>",
             "validator": "required",
@@ -290,7 +482,7 @@ def test_validation_invalid_record_package():
             "values": [{"path": "records/2/releases/0"}],
         },
         {
-            'error_id': None,
+            "error_id": None,
             "message": "'releases' is not a JSON array",
             "message_safe": "<code>releases</code> is not a JSON array",
             "validator": "type",
@@ -307,7 +499,7 @@ def test_validation_invalid_record_package():
             ],
         },
         {
-            'error_id': None,
+            "error_id": None,
             "message": "'tag' is missing but required within 'releases'",
             "message_safe": "<code>tag</code> is missing but required within <code>releases</code>",
             "validator": "required",
@@ -320,7 +512,7 @@ def test_validation_invalid_record_package():
             "values": [{"path": "records/2/releases/0"}],
         },
         {
-            'error_id': None,
+            "error_id": None,
             "message": "'url' is missing but required within 'releases'",
             "message_safe": "<code>url</code> is missing but required within <code>releases</code>",
             "validator": "required",
@@ -333,13 +525,13 @@ def test_validation_invalid_record_package():
             "values": [{"path": "records/1/releases/0"}],
         },
         {
-            'error_id': 'releases_both_embedded_and_linked',
+            "error_id": "releases_both_embedded_and_linked",
             "message": "This array should contain either entirely embedded releases or linked releases. "
-                       "Embedded releases contain an 'id' whereas linked releases do not. "
-                       "Your releases contain a mixture.",
+            "Embedded releases contain an 'id' whereas linked releases do not. "
+            "Your releases contain a mixture.",
             "message_safe": "This array should contain either entirely embedded releases or linked releases. "
-                            "Embedded releases contain an &#39;id&#39; whereas linked releases do not. "
-                            "Your releases contain a mixture.",
+            "Embedded releases contain an &#39;id&#39; whereas linked releases do not. "
+            "Your releases contain a mixture.",
             "validator": "oneOf",
             "assumption": None,
             "message_type": "oneOf",
@@ -350,10 +542,10 @@ def test_validation_invalid_record_package():
             "values": [{"path": "records/4/releases"}, {"path": "records/5/releases"}],
         },
         {
-            'error_id': None,
+            "error_id": None,
             "message": "[] is too short",
             "message_safe": "<code>[]</code> is too short. "
-                            "You must supply at least one value, or remove the item entirely (unless it’s required).",
+            "You must supply at least one value, or remove the item entirely (unless it’s required).",
             "validator": "minItems",
             "assumption": "linked_releases",
             "message_type": "minItems",

--- a/tests/lib/test_converters.py
+++ b/tests/lib/test_converters.py
@@ -185,7 +185,7 @@ def test_convert_csv_1():
         "csv",
         lib_cove_config,
         schema_url=csv_schema_filename,
-    )  # noqa
+    )
 
     assert output["conversion"] == "unflatten"
 

--- a/tests/lib/test_converters.py
+++ b/tests/lib/test_converters.py
@@ -8,19 +8,28 @@ from libcove.config import LibCoveConfig
 
 def test_convert_json_1():
 
-    cove_temp_folder = tempfile.mkdtemp(prefix='lib-cove-ocds-tests-', dir=tempfile.gettempdir())
-    json_filename = os.path.join(os.path.dirname(
-        os.path.realpath(__file__)), 'fixtures', 'converters', 'convert_json_1.json'
+    cove_temp_folder = tempfile.mkdtemp(
+        prefix="lib-cove-ocds-tests-", dir=tempfile.gettempdir()
+    )
+    json_filename = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "fixtures",
+        "converters",
+        "convert_json_1.json",
     )
 
     lib_cove_config = LibCoveConfig()
-    output = convert_json(cove_temp_folder, "", json_filename, lib_cove_config, flatten=True)
+    output = convert_json(
+        cove_temp_folder, "", json_filename, lib_cove_config, flatten=True
+    )
 
-    assert output['converted_url'] == '/flattened'
-    assert len(output['conversion_warning_messages']) == 0
-    assert output['conversion'] == 'flatten'
+    assert output["converted_url"] == "/flattened"
+    assert len(output["conversion_warning_messages"]) == 0
+    assert output["conversion"] == "flatten"
 
-    conversion_warning_messages_name = os.path.join(cove_temp_folder, "conversion_warning_messages.json")
+    conversion_warning_messages_name = os.path.join(
+        cove_temp_folder, "conversion_warning_messages.json"
+    )
     assert os.path.isfile(conversion_warning_messages_name)
     with open(conversion_warning_messages_name) as fp:
         conversion_warning_messages_data = json.load(fp)
@@ -28,74 +37,101 @@ def test_convert_json_1():
 
     assert os.path.isfile(os.path.join(cove_temp_folder, "flattened", "main.csv"))
 
-    with open(os.path.join(cove_temp_folder, "flattened", "main.csv"), 'r') as csvfile:
+    with open(os.path.join(cove_temp_folder, "flattened", "main.csv"), "r") as csvfile:
         csvreader = csv.reader(csvfile)
 
         header = next(csvreader)
-        assert header[0] == 'id'
-        assert header[1] == 'title'
+        assert header[0] == "id"
+        assert header[1] == "title"
 
         row1 = next(csvreader)
-        assert row1[0] == '1'
-        assert row1[1] == 'Cat'
+        assert row1[0] == "1"
+        assert row1[1] == "Cat"
 
         row2 = next(csvreader)
-        assert row2[0] == '2'
-        assert row2[1] == 'Hat'
+        assert row2[0] == "2"
+        assert row2[1] == "Hat"
 
 
 def test_convert_xml_1():
 
-    cove_temp_folder = tempfile.mkdtemp(prefix='lib-cove-ocds-tests-', dir=tempfile.gettempdir())
-    xml_filename = os.path.join(os.path.dirname(
-        os.path.realpath(__file__)), 'fixtures', 'converters', 'convert_1.xml'
+    cove_temp_folder = tempfile.mkdtemp(
+        prefix="lib-cove-ocds-tests-", dir=tempfile.gettempdir()
+    )
+    xml_filename = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "fixtures",
+        "converters",
+        "convert_1.xml",
     )
 
     lib_cove_config = LibCoveConfig()
-    output = convert_json(cove_temp_folder, "", xml_filename, lib_cove_config, flatten=True,
-                          xml=True, root_list_path='iati-activity')
+    output = convert_json(
+        cove_temp_folder,
+        "",
+        xml_filename,
+        lib_cove_config,
+        flatten=True,
+        xml=True,
+        root_list_path="iati-activity",
+    )
 
-    assert output['converted_url'] == '/flattened'
-    assert len(output['conversion_warning_messages']) == 0
-    assert output['conversion'] == 'flatten'
+    assert output["converted_url"] == "/flattened"
+    assert len(output["conversion_warning_messages"]) == 0
+    assert output["conversion"] == "flatten"
 
-    conversion_warning_messages_name = os.path.join(cove_temp_folder, "conversion_warning_messages.json")
+    conversion_warning_messages_name = os.path.join(
+        cove_temp_folder, "conversion_warning_messages.json"
+    )
     assert os.path.isfile(conversion_warning_messages_name)
     with open(conversion_warning_messages_name) as fp:
         conversion_warning_messages_data = json.load(fp)
     assert conversion_warning_messages_data == []
 
     assert os.path.isfile(os.path.join(cove_temp_folder, "flattened.xlsx"))
-    assert os.path.isfile(os.path.join(cove_temp_folder, "flattened", "iati-activity.csv"))
+    assert os.path.isfile(
+        os.path.join(cove_temp_folder, "flattened", "iati-activity.csv")
+    )
 
-    with open(os.path.join(cove_temp_folder, "flattened", "iati-activity.csv"), 'r') as csvfile:
+    with open(
+        os.path.join(cove_temp_folder, "flattened", "iati-activity.csv"), "r"
+    ) as csvfile:
         csvreader = csv.reader(csvfile)
 
         header = next(csvreader)
-        assert header[0] == '@default-currency'
-        assert header[1] == 'iati-identifier'
+        assert header[0] == "@default-currency"
+        assert header[1] == "iati-identifier"
 
         row1 = next(csvreader)
-        assert row1[0] == 'GBP'
-        assert row1[1] == 'GB-TEST-13-example_ODSC_2019'
+        assert row1[0] == "GBP"
+        assert row1[1] == "GB-TEST-13-example_ODSC_2019"
 
 
 def test_convert_json_root_is_list_1():
 
-    cove_temp_folder = tempfile.mkdtemp(prefix='lib-cove-ocds-tests-', dir=tempfile.gettempdir())
-    json_filename = os.path.join(os.path.dirname(
-        os.path.realpath(__file__)), 'fixtures', 'converters', 'convert_json_root_is_list_1.json'
+    cove_temp_folder = tempfile.mkdtemp(
+        prefix="lib-cove-ocds-tests-", dir=tempfile.gettempdir()
+    )
+    json_filename = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "fixtures",
+        "converters",
+        "convert_json_root_is_list_1.json",
     )
 
     lib_cove_config = LibCoveConfig()
-    lib_cove_config.config['root_is_list'] = True
-    output = convert_json(cove_temp_folder, "", json_filename, lib_cove_config, flatten=True)
+    lib_cove_config.config["root_is_list"] = True
+    output = convert_json(
+        cove_temp_folder, "", json_filename, lib_cove_config, flatten=True
+    )
 
-    assert output['converted_url'] == '/flattened'
-    assert len(output['conversion_warning_messages']) == 0
-    assert output['conversion'] == 'flatten'
+    assert output["converted_url"] == "/flattened"
+    assert len(output["conversion_warning_messages"]) == 0
+    assert output["conversion"] == "flatten"
 
-    conversion_warning_messages_name = os.path.join(cove_temp_folder, "conversion_warning_messages.json")
+    conversion_warning_messages_name = os.path.join(
+        cove_temp_folder, "conversion_warning_messages.json"
+    )
     assert os.path.isfile(conversion_warning_messages_name)
     with open(conversion_warning_messages_name) as fp:
         conversion_warning_messages_data = json.load(fp)
@@ -103,50 +139,59 @@ def test_convert_json_root_is_list_1():
 
     assert os.path.isfile(os.path.join(cove_temp_folder, "flattened", "main.csv"))
 
-    with open(os.path.join(cove_temp_folder, "flattened", "main.csv"), 'r') as csvfile:
+    with open(os.path.join(cove_temp_folder, "flattened", "main.csv"), "r") as csvfile:
         csvreader = csv.reader(csvfile)
 
         header = next(csvreader)
-        assert header[0] == 'id'
-        assert header[1] == 'title'
+        assert header[0] == "id"
+        assert header[1] == "title"
 
         row1 = next(csvreader)
-        assert row1[0] == '1'
-        assert row1[1] == 'Cat'
+        assert row1[0] == "1"
+        assert row1[1] == "Cat"
 
         row2 = next(csvreader)
-        assert row2[0] == '2'
-        assert row2[1] == 'Hat'
+        assert row2[0] == "2"
+        assert row2[1] == "Hat"
 
 
 def test_convert_csv_1():
 
-    cove_temp_folder = tempfile.mkdtemp(prefix='lib-cove-ocds-tests-', dir=tempfile.gettempdir())
-    csv_filename = os.path.join(os.path.dirname(
-        os.path.realpath(__file__)), 'fixtures', 'converters', 'convert_csv_1.csv'
+    cove_temp_folder = tempfile.mkdtemp(
+        prefix="lib-cove-ocds-tests-", dir=tempfile.gettempdir()
     )
-    csv_schema_filename = os.path.join(os.path.dirname(
-        os.path.realpath(__file__)), 'fixtures', 'converters', 'convert_csv_1_schema.json'
+    csv_filename = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "fixtures",
+        "converters",
+        "convert_csv_1.csv",
+    )
+    csv_schema_filename = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "fixtures",
+        "converters",
+        "convert_csv_1_schema.json",
     )
 
     lib_cove_config = LibCoveConfig()
-    lib_cove_config.config['id_name'] = 'thing_id'
-    lib_cove_config.config['root_is_list'] = True
+    lib_cove_config.config["id_name"] = "thing_id"
+    lib_cove_config.config["root_is_list"] = True
 
-    output = convert_spreadsheet(cove_temp_folder, "", csv_filename, 'csv', lib_cove_config, schema_url=csv_schema_filename) # noqa
+    output = convert_spreadsheet(
+        cove_temp_folder,
+        "",
+        csv_filename,
+        "csv",
+        lib_cove_config,
+        schema_url=csv_schema_filename,
+    )  # noqa
 
-    assert output['conversion'] == 'unflatten'
+    assert output["conversion"] == "unflatten"
 
-    with open(output['converted_path']) as fp:
+    with open(output["converted_path"]) as fp:
         json_data = json.load(fp)
 
     assert json_data == [
-            {
-                "thing_id": "1",
-                "title": "Cat"
-            },
-            {
-                "thing_id": "2",
-                "title": "Hat"
-            }
-        ]
+        {"thing_id": "1", "title": "Cat"},
+        {"thing_id": "2", "title": "Hat"},
+    ]

--- a/tests/lib/test_converters.py
+++ b/tests/lib/test_converters.py
@@ -1,9 +1,10 @@
-import tempfile
-import os
-import json
 import csv
-from libcove.lib.converters import convert_json, convert_spreadsheet
+import json
+import os
+import tempfile
+
 from libcove.config import LibCoveConfig
+from libcove.lib.converters import convert_json, convert_spreadsheet
 
 
 def test_convert_json_1():

--- a/tests/lib/test_tools.py
+++ b/tests/lib/test_tools.py
@@ -4,31 +4,31 @@ from libcove.lib.tools import get_file_type, ignore_errors
 from libcove.lib.exceptions import UnrecognisedFileType
 
 
-@pytest.mark.parametrize('file_name', ['basic.xlsx', 'basic.XLSX'])
+@pytest.mark.parametrize("file_name", ["basic.xlsx", "basic.XLSX"])
 def test_get_file_type_xlsx_string(file_name):
-    assert get_file_type(file_name) == 'xlsx'
+    assert get_file_type(file_name) == "xlsx"
 
 
-@pytest.mark.parametrize('file_name', ['test.csv', 'test.CSV'])
+@pytest.mark.parametrize("file_name", ["test.csv", "test.CSV"])
 def test_get_file_type_csv_string(file_name):
-    assert get_file_type(file_name) == 'csv'
+    assert get_file_type(file_name) == "csv"
 
 
-@pytest.mark.parametrize('file_name', ['test.json', 'test.JSON'])
+@pytest.mark.parametrize("file_name", ["test.json", "test.JSON"])
 def test_get_file_type_json_string(file_name):
-    assert get_file_type(file_name) == 'json'
+    assert get_file_type(file_name) == "json"
 
 
 def test_get_file_type_json_noextension_string():
     file_name = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), 'fixtures', 'tools', 'test'
+        os.path.dirname(os.path.realpath(__file__)), "fixtures", "tools", "test"
     )
-    assert get_file_type(file_name) == 'json'
+    assert get_file_type(file_name) == "json"
 
 
 def test_get_file_unrecognised_file_type_string():
     with pytest.raises(UnrecognisedFileType):
-        get_file_type('test')
+        get_file_type("test")
 
 
 def test_ignore_errors():
@@ -36,13 +36,7 @@ def test_ignore_errors():
 
     # Test data that would in real usage come from having parsed a json
     # document
-    test_data = {
-        'A': [
-            {'B': 'C'},
-            {'F': 'G'},
-        ],
-        'E': object(),
-    }
+    test_data = {"A": [{"B": "C"}, {"F": "G"}], "E": object()}
 
     class obj_with_attr(object):
         test = None
@@ -50,15 +44,15 @@ def test_ignore_errors():
     @ignore_errors
     def check_data(json_data):
         # KeyError
-        json_data['B']
+        json_data["B"]
         # IndexError
-        json_data['A'][2]
+        json_data["A"][2]
         # TypeError
-        json_data['A'][0]['B'] + 2
+        json_data["A"][0]["B"] + 2
         # AttributeError
-        json_data['E'].test
+        json_data["E"].test
         # ValueError
-        int(json_data['A'][1]['F'])
+        int(json_data["A"][1]["F"])
 
     # Should pass without any exceptions
     check_data(test_data, ignore_errors=True)
@@ -71,25 +65,25 @@ def test_ignore_errors():
         pass
 
     try:
-        test_data['B'] = "exist"
+        test_data["B"] = "exist"
         check_data(test_data, ignore_errors=False)
     except IndexError:
         pass
 
     try:
-        test_data['A'].append({})
+        test_data["A"].append({})
         check_data(test_data, ignore_errors=False)
     except TypeError:
         pass
 
     try:
-        test_data['A'][0]['B'] = 1
+        test_data["A"][0]["B"] = 1
         check_data(test_data, ignore_errors=False)
     except AttributeError:
         pass
 
     try:
-        test_data['E'] = obj_with_attr()
+        test_data["E"] = obj_with_attr()
         check_data(test_data, ignore_errors=False)
     except ValueError as e:
         print("Got %s " % e)

--- a/tests/lib/test_tools.py
+++ b/tests/lib/test_tools.py
@@ -1,7 +1,9 @@
-import pytest
 import os
-from libcove.lib.tools import get_file_type, ignore_errors
+
+import pytest
+
 from libcove.lib.exceptions import UnrecognisedFileType
+from libcove.lib.tools import get_file_type, ignore_errors
 
 
 @pytest.mark.parametrize("file_name", ["basic.xlsx", "basic.XLSX"])


### PR DESCRIPTION
As discussed at the dev retreat - format the Python code in this repository with black (general Python code formatter) and isort (sorts imports).

A downside is black only works with Python3.6, although it will make changes that are compatible with earlier versions (including Python 2). I have added if statements to the Travis config to deal with this.

flake8 is still used, but without any style checking.

I'd quite like to get this merged promptly if possible, so that I can try it out for changes to this repo.