### PR TITLE
Depend on rfc3987 and strict-rfc3339 to validate formats correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.14.0] - 2020-02-13
+
+### Added
+
+- Depend on rfc3987 and strict-rfc3339 (optional dependencies of jsonschema) in order to validate URIs and date-times correctly [lib-cove-bods#54](https://github.com/openownership/lib-cove-bods/pull/54#issuecomment-585303356)
+
 ## [0.13.0] - 2020-01-09
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="libcove",
-    version="0.13.0",
+    version="0.14.0",
     author="Open Data Services",
     author_email="code@opendataservices.coop",
     url="https://github.com/OpenDataServices/lib-cove",
@@ -19,6 +19,10 @@ setup(
         "json-merge-patch",
         "cached-property",
         "flattentool>=0.5.0",
+        # Required for jsonschema to validate URIs
+        "rfc3987",
+        # Required for jsonschema to validate date-time
+        "strict-rfc3339",
     ],
     classifiers=[
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)"


### PR DESCRIPTION
These optional dependencies of `jsonschema` are required to validate URIs and date-times correctly.

https://github.com/openownership/lib-cove-bods/pull/54#issuecomment-585303356