### PR TITLE
Have CustomRefResolver and CustomJsonrefLoader respect cache_all_requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.19.0] - 2020-09-28
+
 ### Changed
 
 - CustomRefResolver and CustomJsonrefLoader now respect `cache_all_requests` in the config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- CustomRefResolver and CustomJsonrefLoader now respect `cache_all_requests` in the config
+
 ## [0.18.0] - 2020-08-26
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="libcove",
-    version="0.18.0",
+    version="0.19.0",
     author="Open Data Services",
     author_email="code@opendataservices.coop",
     url="https://github.com/OpenDataServices/lib-cove",

--- a/tests/lib/test_common.py
+++ b/tests/lib/test_common.py
@@ -396,6 +396,7 @@ def test_get_orgids_prefixes_live():
 class DummyReleaseSchemaObj:
     def __init__(self, schema_host):
         self.schema_host = schema_host
+        self.config = None
 
     def get_pkg_schema_obj(self):
         with open(os.path.join(self.schema_host, "release-package-schema.json")) as fp:
@@ -406,6 +407,7 @@ class DummyReleaseSchemaObj:
 class DummyRecordSchemaObj:
     def __init__(self, schema_host):
         self.schema_host = schema_host
+        self.config = None
 
     def get_pkg_schema_obj(self):
         with open(os.path.join(self.schema_host, "record-package-schema.json")) as fp:


### PR DESCRIPTION
This cuts test time down on my machine for lib-cove-ocds from 40s to 6s (paired with corresponding changes in that repo).

This will also improve performance in Kingfisher Process, so that jsonschema and jsonref aren't repeatedly requesting URLs.