### PR TITLE
Use dict instead of OrderedDict (Python >= 3.6)

### DIFF
--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -6,7 +6,6 @@ import functools
 import json
 import os
 import re
-from collections import OrderedDict
 from urllib.parse import urljoin, urlparse
 
 import jsonref
@@ -199,7 +198,7 @@ class SchemaJsonMixin:
 
     @property
     def _schema_obj(self):
-        return json.loads(self.schema_str, object_pairs_hook=OrderedDict)
+        return json.loads(self.schema_str)
 
     @property
     def _pkg_schema_obj(self):
@@ -323,7 +322,7 @@ def load_core_codelists(codelist_url, unique_files, config=None):
 @functools.lru_cache()
 def _deref_schema(schema_str, schema_host, cache=None):
     loader = CustomJsonrefLoader(schema_url=schema_host, cache=cache)
-    deref_obj = jsonref.loads(schema_str, loader=loader, object_pairs_hook=OrderedDict)
+    deref_obj = jsonref.loads(schema_str, loader=loader)
     # Force evaluation of jsonref.loads here
     repr(deref_obj)
     return deref_obj
@@ -557,7 +556,7 @@ def get_additional_codelist_values(schema_obj, json_data):
 def get_additional_fields_info(json_data, schema_fields, context, fields_regex=False):
     fields_present = get_fields_present_with_examples(json_data)
 
-    additional_fields = collections.OrderedDict()
+    additional_fields = {}
     root_additional_fields = set()
 
     for field, field_info in fields_present.items():
@@ -576,7 +575,7 @@ def get_additional_fields_info(json_data, schema_fields, context, fields_regex=F
                 break
         else:
             field_info["root_additional_field"] = True
-            field_info["additional_field_descendance"] = collections.OrderedDict()
+            field_info["additional_field_descendance"] = {}
             root_additional_fields.add(field)
 
         field_info["path"] = "/".join(field.split("/")[:-1])
@@ -775,29 +774,24 @@ def get_schema_validation_errors(
         if header_extra is None:
             header_extra = header
 
-        unique_validator_key = OrderedDict(
-            [
-                ("message", message),
-                ("message_safe", conditional_escape(message_safe)),
-                ("validator", e.validator),
-                ("assumption", e.assumption if hasattr(e, "assumption") else None),
-                # Don't pass this value for 'enum' and 'required' validators,
-                # because it is not needed, and it will mean less grouping, which
-                # we don't want.
-                (
-                    "validator_value",
-                    e.validator_value
-                    if e.validator not in ["enum", "required"]
-                    else None,
-                ),
-                ("message_type", validator_type),
-                ("path_no_number", path_no_number),
-                ("header", header),
-                ("header_extra", header_extra),
-                ("null_clause", null_clause),
-                ("error_id", e.error_id if hasattr(e, "error_id") else None),
-            ]
-        )
+        unique_validator_key = {
+            "message": message,
+            "message_safe": conditional_escape(message_safe),
+            "validator": e.validator,
+            "assumption": e.assumption if hasattr(e, "assumption") else None,
+            # Don't pass this value for 'enum' and 'required' validators,
+            # because it is not needed, and it will mean less grouping, which
+            # we don't want.
+            "validator_value": e.validator_value
+            if e.validator not in ["enum", "required"]
+            else None,
+            "message_type": validator_type,
+            "path_no_number": path_no_number,
+            "header": header,
+            "header_extra": header_extra,
+            "null_clause": null_clause,
+            "error_id": e.error_id if hasattr(e, "error_id") else None,
+        }
         validation_errors[json.dumps(unique_validator_key)].append(value)
     return dict(validation_errors)
 
@@ -867,10 +861,10 @@ def get_json_data_deprecated_fields(json_data_paths, schema_obj):
     deprecated_json_data_paths = [
         path for path in deprecated_schema_paths if path[0] in json_data_paths
     ]
-    # Generate an OrderedDict sorted by deprecated field names (keys) mapping
+    # Generate a dict sorted by deprecated field names (keys) mapping
     # to a unordered tuple of tuples:
     # {deprecated_field: ((path, path... ), (version, description))}
-    deprecated_fields = OrderedDict()
+    deprecated_fields = {}
     for generic_path in sorted(deprecated_json_data_paths, key=lambda tup: tup[0][-1]):
         deprecated_fields[generic_path[0][-1]] = tuple()
 
@@ -889,7 +883,7 @@ def get_json_data_deprecated_fields(json_data_paths, schema_obj):
             )
 
     # Order the path tuples in values for deprecated_fields.
-    deprecated_fields_output = OrderedDict()
+    deprecated_fields_output = {}
     for field, paths in deprecated_fields.items():
         sorted_paths = tuple(sorted(paths[0]))
 
@@ -949,7 +943,7 @@ def _generate_data_path(json_data, path=()):
 
 
 def get_fields_present_with_examples(*args, **kwargs):
-    counter = collections.OrderedDict()
+    counter = {}
     for key, value in fields_present_generator(*args, **kwargs):
         if key not in counter:
             counter[key] = {"count": 0, "examples": []}

--- a/tests/lib/test_common.py
+++ b/tests/lib/test_common.py
@@ -1,6 +1,5 @@
 import json
 import os
-from collections import OrderedDict
 
 import pytest
 
@@ -43,27 +42,19 @@ def test_get_json_data_deprecated_fields():
     deprecated_data_fields = get_json_data_deprecated_fields(
         json_data_paths, schema_obj
     )
-    expected_result = OrderedDict(
-        [
-            (
-                "initiationType",
-                {
-                    "paths": ("releases/0", "releases/1"),
-                    "explanation": (
-                        "1.1",
-                        "Not a useful field as always has to be tender",
-                    ),
-                },
+    expected_result = {
+        "initiationType": {
+            "paths": ("releases/0", "releases/1"),
+            "explanation": (
+                "1.1",
+                "Not a useful field as always has to be tender",
             ),
-            (
-                "quantity",
-                {
-                    "paths": ("releases/0/tender/items/0",),
-                    "explanation": ("1.1", "Nobody cares about quantities"),
-                },
-            ),
-        ]
-    )
+        },
+        "quantity": {
+            "paths": ("releases/0/tender/items/0",),
+            "explanation": ("1.1", "Nobody cares about quantities"),
+        },
+    }
     for field_name in expected_result.keys():
         assert field_name in deprecated_data_fields
         assert (


### PR DESCRIPTION
Dictionaries will be in disorder in Python 3.5, but it's EOL anyway.

Related https://github.com/open-contracting/lib-cove-oc4ids/issues/23