### PR TITLE
common: Log warning for invalid JSON Schema in which "properties" values aren't JSON Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't error when JSON schema "properties" values aren't JSON Schema, and log a warning instead https://github.com/OpenDataServices/lib-cove/pull/71
+
 ## [0.20.1] - 2020-10-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.20.2] - 2020-11-04
+
 ### Fixed
 
 - Don't error when JSON schema "properties" values aren't JSON Schema, and log a warning instead https://github.com/OpenDataServices/lib-cove/pull/71

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -4,6 +4,7 @@ import datetime
 import fcntl
 import functools
 import json
+import logging
 import os
 import re
 from collections import OrderedDict
@@ -42,6 +43,8 @@ validation_error_template_lookup = {
     "object": "{}'{}' is not a JSON object",
     "array": "{}'{}' is not a JSON array",
 }
+
+logger = logging.getLogger(__name__)
 
 
 def unique_ids(validator, ui, instance, schema, id_name="id"):
@@ -1105,6 +1108,14 @@ def add_is_codelist(obj):
     release.tag in core schema at the moment."""
 
     for prop, value in obj.get("properties", {}).items():
+        if not isinstance(value, dict):
+            logger.warning(
+                "A 'properties' object contains a {!r} value that is not a JSON Schema: {!r}".format(
+                    prop, value
+                )
+            )
+            continue
+
         if "codelist" in value:
             if "array" in value.get("type", ""):
                 value["items"]["isCodelist"] = True

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="libcove",
-    version="0.20.1",
+    version="0.20.2",
     author="Open Data Services",
     author_email="code@opendataservices.coop",
     url="https://github.com/OpenDataServices/lib-cove",


### PR DESCRIPTION
Fixes recent Sentry errors in cove-ocds and kingfisher-process.

Occurs because an MTender extension does:

```json
    "ValueDifference": {
      "title": "",
      "description": "",
      "type": "object",
      "properties": {
        "value": "",
        "unit": {
          "$ref": "#/definitions/Unit"
        }
      },
      "extension": "eAuction"
    },
```

`value` can't be a string. It must be a JSON Schema.

Problem is in https://raw.githubusercontent.com/eOCDS-Extensions/eOCDS-eAuction/master/release-schema.json

cc @duncandewhurst