### PR TITLE
Remove dependency on fcntl (improves Windows support)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       run: pip install black
 
     - name: Isort
-      run: isort --check-only --recursive *.py */
+      run: isort --check-only *.py */
 
     - name: Flake8
       run: flake8

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,6 @@
 -e .
 pytest
 flake8
+freezegun
 isort
+requests-mock


### PR DESCRIPTION
Use a create and rename strategy instead of locking the file here.
Fixes Issue #53

Add comprehensive tests for the function.