### PR TITLE
lint: Move black into requirements, drop Python 3.5 from CI,

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,6 @@ jobs:
     - name: Install
       run: pip install -r requirements_dev.txt
 
-    - name: Install Black
-      run: pip install black
-
     - name: Isort
       run: isort --check-only *.py */
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
         # https://github.com/OpenDataServices/lib-cove/issues/53
         # We also only use Linux servers, so don't test on Mac
         os: [ubuntu-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v1

--- a/libcove/lib/tools.py
+++ b/libcove/lib/tools.py
@@ -85,7 +85,7 @@ def update_docs(document_parent, counter):
 
 
 def get_file_type(file_name):
-    """ Takes an filename (type string), and returns a string saying what type it is."""
+    """Takes an filename (type string), and returns a string saying what type it is."""
     # Older versions of this could take DJango objects to.
     # Tho we don't really want to support that, put in a check for that.
     if not isinstance(file_name, str) and hasattr(file_name, "path"):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,4 @@ flake8
 freezegun
 isort
 requests-mock
+black

--- a/tests/lib/test_tools.py
+++ b/tests/lib/test_tools.py
@@ -34,7 +34,7 @@ def test_get_file_unrecognised_file_type_string():
 
 
 def test_ignore_errors():
-    """ Test the ignore_errors function """
+    """Test the ignore_errors function"""
 
     # Test data that would in real usage come from having parsed a json
     # document


### PR DESCRIPTION
run latest version of black against the code.