### PR TITLE
tests: "properties" values that aren't JSON schema don't cause exception

### DIFF
--- a/tests/lib/test_common.py
+++ b/tests/lib/test_common.py
@@ -782,6 +782,26 @@ def test_dont_error_on_decimal_in_unique_validator_key():
     assert "[Decimal('3.1')] is too short" in validation_error_json
 
 
+def test_property_that_is_not_json_schema_doesnt_raise_exception(caplog, tmpdir):
+    tmpdir.join("test.json").write(
+        json.dumps({"properties": {"bad_property": "not_a_json_schema"}})
+    )
+
+    class DummySchemaObj:
+        config = None
+        schema_host = os.path.join(str(tmpdir), "")
+
+        def get_pkg_schema_obj(self):
+            return {"$ref": "test.json"}
+
+    validation_errors = get_schema_validation_errors({}, DummySchemaObj(), "", {}, {})
+    assert validation_errors == {}
+    assert (
+        "A 'properties' object contains a 'bad_property' value that is not a JSON Schema: 'not_a_json_schema'"
+        in caplog.text
+    )
+
+
 @pytest.mark.parametrize(
     ("filedate", "checkdate", "result"),
     (


### PR DESCRIPTION
This is the test relating to this PR:
https://github.com/OpenDataServices/lib-cove/pull/71/files