### PR TITLE
Require jsonschema >= 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     long_description="A data review library",
     install_requires=[
         "jsonref",
-        "jsonschema",
-        "requests>=3.0.0",
+        "jsonschema>=3.0.0",
+        "requests",
         "cached-property",
         "flattentool>=0.11.0",
         # Required for jsonschema to validate URIs

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[
         "jsonref",
         "jsonschema",
-        "requests",
+        "requests>3",
         "cached-property",
         "flattentool>=0.11.0",
         # Required for jsonschema to validate URIs

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[
         "jsonref",
         "jsonschema",
-        "requests>3",
+        "requests>=3.0.0",
         "cached-property",
         "flattentool>=0.11.0",
         # Required for jsonschema to validate URIs


### PR DESCRIPTION
Required for https://github.com/OpenDataServices/lib-cove/blob/b5de38ee3a71ac262d773c456c6665b7869b2112/libcove/lib/common.py#L28

Fixes the following error when running the `libcoveoc4ids` cli:

```
Traceback (most recent call last):
  File "/usr/local/bin/libcoveoc4ids", line 5, in <module>
    from libcoveoc4ids.cli.__main__ import main
  File "/usr/local/lib/python3.7/dist-packages/libcoveoc4ids/cli/__main__.py", line 5, in <module>
    from libcoveoc4ids.api import jsonlib, oc4ids_json_output, using_orjson
  File "/usr/local/lib/python3.7/dist-packages/libcoveoc4ids/api.py", line 5, in <module>
    from libcoveoc4ids.common_checks import common_checks_oc4ids
  File "/usr/local/lib/python3.7/dist-packages/libcoveoc4ids/common_checks.py", line 1, in <module>
    from libcove.lib.common import common_checks_context, get_additional_codelist_values, get_field_coverage
  File "/usr/local/lib/python3.7/dist-packages/libcove/lib/common.py", line 28, in <module>
    from jsonschema.exceptions import UndefinedTypeCheck, ValidationError
ImportError: cannot import name 'UndefinedTypeCheck' from 'jsonschema.exceptions' (/usr/local/lib/python3.7/dist-packages/jsonschema/exceptions.py)
```
I'm not sure if this might break something else though.

Should we add a test for the cli?