### PR TITLE
fix: Add compatibility for both jsonref 0.x and 1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=find_packages(),
     long_description="A data review library",
     install_requires=[
-        "jsonref<1",
+        "jsonref",
         "jsonschema>=3,<4",
         "requests",
         "cached-property",


### PR DESCRIPTION
In jsonref 0.x, `jsonref.jsonloader` is an instance of `JsonLoader()` that contains caching. In 0.x, `jsonref.jsonloader` is just a function that does no caching (caching is instead done in `replace_refs`).

After this change, that caching by `JsonLoader()` (which had been performed in its `__call__` method, which was never overridden by libcove) is no longer present if using jsonref 0.x.

That said, the simple fix to get caching performance in downstream libraries is to upgrade to jsonref 1.x.