### PR TITLE
fix: Numeric "id" values no longer cause an exception while yielding a validation error about non-unique IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Numeric "id" values no longer cause an exception while yielding a validation error about non-unique IDs.
+
 ## [0.27.1] - 2022-10-28
 
 ### Fixed

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -134,7 +134,7 @@ def unique_ids(validator, ui, instance, schema, id_names=["id"]):
                 msg = "Non-unique {} values".format(id_names[0])
             else:
                 msg = "Non-unique combination of {} values".format(", ".join(id_names))
-            err = ValidationError(msg, instance=", ".join(non_unique_id))
+            err = ValidationError(msg, instance=", ".join(map(str, non_unique_id)))
             err.error_id = "uniqueItems_with_{}".format("__".join(id_names))
             yield err
 

--- a/tests/lib/test_common.py
+++ b/tests/lib/test_common.py
@@ -34,6 +34,7 @@ def test_unique_ids_False():
     assert list(unique_ids(validator, ui, [], schema)) == []
     assert list(unique_ids(validator, ui, [{}, {}], schema)) == []
     assert list(unique_ids(validator, ui, [{"id": "1"}, {"id": "2"}], schema)) == []
+    assert list(unique_ids(validator, ui, [{"id": "1"}, {"id": 1}], schema)) == []
 
 
 def test_unique_ids_True():
@@ -103,6 +104,9 @@ def test_unique_ids_True():
     ) == [("Non-unique id values", "uniqueItems_with_id")]
     assert validation_errors_to_tuples(
         unique_ids(validator, ui, [{"id": "1"}, {"id": "1"}], schema)
+    ) == [("Non-unique id values", "uniqueItems_with_id")]
+    assert validation_errors_to_tuples(
+        unique_ids(validator, ui, [{"id": 1}, {"id": 1}], schema)
     ) == [("Non-unique id values", "uniqueItems_with_id")]
 
     assert validation_errors_to_tuples(


### PR DESCRIPTION
fixes #101

replaces #102

You can undo the change to common.py to see one of the new tests fail.