### PR TITLE
fix: Use sentence case for "Array element"

### DIFF
--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -887,7 +887,7 @@ def get_schema_validation_errors(
             header = e.path[-1]
             if isinstance(e.path[-1], int) and len(e.path) >= 2:
                 # We're dealing with elements in an array of items at this point
-                pre_header = "Array Element "
+                pre_header = "Array element "
                 header_extra = "{}/[number]".format(e.path[-2])
 
         null_clause = ""


### PR DESCRIPTION
closes #28 

So we get messages like "Array element '...' is not a string." instead of "Array Element '...' is not a string."