### PR TITLE
fix: Force jsonschema to use our validator

### DIFF
--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -720,11 +720,9 @@ def get_additional_codelist_values(schema_obj, json_data):
             path_string = "/".join(path_no_num)
 
             if path_string not in additional_codelist_values:
-
                 codelist_url = schema_obj.codelists + codelist
                 codelist_amend_urls = []
                 if hasattr(schema_obj, "extended_codelist_urls"):
-
                     # Replace URL if this codelist is overridden by an extension.
                     # Last one to be applied wins.
                     if schema_obj.extended_codelist_urls.get(codelist):
@@ -771,7 +769,6 @@ def get_additional_fields_info(json_data, schema_fields, context, fields_regex=F
     root_additional_fields = set()
 
     for field, field_info in fields_present.items():
-
         if field in schema_fields:
             continue
         if fields_regex and LANGUAGE_RE.search(field.split("/")[-1]):
@@ -804,7 +801,6 @@ def get_counts_additional_fields(
     fields_regex=False,
     additional_fields_info=None,
 ):
-
     if not additional_fields_info:
         schema_fields = schema_obj.get_pkg_schema_fields()
         additional_fields_info = get_additional_fields_info(
@@ -849,6 +845,12 @@ def get_schema_validation_errors(
             config=getattr(schema_obj, "config", None),
             schema_url=schema_obj.schema_host,
         )
+
+    # Force jsonschema to use our validator.
+    # https://github.com/python-jsonschema/jsonschema/issues/994
+    jsonschema.validators.validates("http://json-schema.org/draft-04/schema#")(
+        validator
+    )
 
     our_validator = validator(
         pkg_schema_obj, format_checker=format_checker, resolver=resolver
@@ -1000,6 +1002,13 @@ def get_schema_validation_errors(
         validation_errors[
             json.dumps(unique_validator_key, default=decimal_default)
         ].append(value)
+
+    # Restore jsonschema's default validator, to not interfere with other software.
+    # https://github.com/python-jsonschema/jsonschema/issues/994
+    jsonschema.validators.validates("http://json-schema.org/draft-04/schema#")(
+        jsonschema.validators.Draft4Validator
+    )
+
     return dict(validation_errors)
 
 

--- a/tests/lib/test_common.py
+++ b/tests/lib/test_common.py
@@ -333,7 +333,6 @@ def test_get_schema_deprecated_paths():
 
 
 def test_schema_dict_fields_generator_release_schema_deprecated_fields():
-
     with open(
         os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
@@ -362,7 +361,6 @@ def test_schema_dict_fields_generator_release_schema_deprecated_fields():
 
 
 def test_schema_dict_fields_generator_schema_with_list_and_oneof():
-
     with open(
         os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
@@ -396,7 +394,6 @@ def test_schema_dict_fields_generator_schema_with_list_and_oneof():
 
 
 def test_fields_present_generator_tenders_releases_2_releases():
-
     with open(
         os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
@@ -449,7 +446,6 @@ def test_fields_present_generator_tenders_releases_2_releases():
 
 
 def test_fields_present_generator_data_root_is_list():
-
     with open(
         os.path.join(
             os.path.dirname(os.path.realpath(__file__)),
@@ -501,7 +497,6 @@ def test_fields_present_generator_data_root_is_list():
 
 
 def test_get_additional_fields_info():
-
     simple_data = {
         "non_additional_field": "a",
         "non_additional_list": [1, 2],
@@ -1227,7 +1222,6 @@ def test_get_field_coverage_oc4ids():
     ),
 )
 def test_oneOfEnumSelectorField(data, count, errors):
-
     with open(common_fixtures("schema_with_one_of_enum_selector_field.json")) as fp:
         schema = json.load(fp)
 

--- a/tests/lib/test_converters.py
+++ b/tests/lib/test_converters.py
@@ -8,7 +8,6 @@ from libcove.lib.converters import convert_json, convert_spreadsheet
 
 
 def test_convert_json_1():
-
     cove_temp_folder = tempfile.mkdtemp(
         prefix="lib-cove-ocds-tests-", dir=tempfile.gettempdir()
     )
@@ -55,7 +54,6 @@ def test_convert_json_1():
 
 
 def test_convert_activity_xml_1():
-
     cove_temp_folder = tempfile.mkdtemp(
         prefix="lib-cove-iati-tests-", dir=tempfile.gettempdir()
     )
@@ -110,7 +108,6 @@ def test_convert_activity_xml_1():
 
 
 def test_convert_org_xml_1():
-
     cove_temp_folder = tempfile.mkdtemp(
         prefix="lib-cove-iati-tests-", dir=tempfile.gettempdir()
     )
@@ -166,7 +163,6 @@ def test_convert_org_xml_1():
 
 
 def test_convert_json_root_is_list_1():
-
     cove_temp_folder = tempfile.mkdtemp(
         prefix="lib-cove-ocds-tests-", dir=tempfile.gettempdir()
     )
@@ -214,7 +210,6 @@ def test_convert_json_root_is_list_1():
 
 
 def test_convert_csv_1():
-
     cove_temp_folder = tempfile.mkdtemp(
         prefix="lib-cove-ocds-tests-", dir=tempfile.gettempdir()
     )


### PR DESCRIPTION
Otherwise, jsonschema switches back to the default Draft4Validator: https://github.com/python-jsonschema/jsonschema/issues/994 This code seems to be the recommended solution, per that issue.

There are some whitespace changes because black was complaining about the lint workflow.

---

I also tried the following patch, but `extend`, doesn't seem to behave as documented. (The `validators` argument doesn't cause the validators to be overridden for `$ref`erenced schema.)

Note that, even if the below diff were to work, some lib-cove-* libraries (like lib-cove-ocds) override `validator.VALIDATORS` directly (which is not part of jsonschema's public API).

Allowing such overrides while following jsonschema's public API would require more significant refactoring in lib-cove.

```diff
diff --git a/libcove/lib/common.py b/libcove/lib/common.py
index f5c508b..6568b2f 100644
--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -92,17 +92,6 @@ class TypeChecker:
         raise UndefinedTypeCheck(type)
 
 
-# Because we will be changing items on this validator, it's important we take a copy!
-# Otherwise we could cause conflicts with other software in the same process.
-validator = jsonschema.validators.extend(
-    jsonschema.validators.Draft4Validator,
-    validators={
-        "type": type_validator,
-    },
-    type_checker=TypeChecker(),
-)
-
-uniqueItemsValidator = validator.VALIDATORS.pop("uniqueItems")
 LANGUAGE_RE = re.compile(
     "^(.*_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$"
 )
@@ -345,13 +334,23 @@ def dependencies_extra_data(validator, dependencies, instance, schema):
                 yield error
 
 
-validator.VALIDATORS.pop("patternProperties")
-validator.VALIDATORS["uniqueItems"] = unique_ids
-validator.VALIDATORS["required"] = required_draft4
-validator.VALIDATORS["oneOf"] = oneOf_draft4
-validator.VALIDATORS["dependencies"] = dependencies_extra_data
-validator.VALIDATORS["additionalItems"] = additionalItems_extra_data
-validator.VALIDATORS["additionalProperties"] = additionalProperties_extra_data
+
+# Because we will be changing items on this validator, it's important we take a copy!
+# Otherwise we could cause conflicts with other software in the same process.
+validator = jsonschema.validators.extend(
+    jsonschema.validators.Draft4Validator,
+    validators={
+        "type": type_validator,
+        "required": required_draft4,
+        "oneOf": oneOf_draft4,
+        "dependencies": dependencies_extra_data,
+        "additionalItems": additionalItems_extra_data,
+        "additionalProperties": additionalProperties_extra_data,
+        "patternProperties": lambda *args, **kwargs: None,
+        "uniqueItems": lambda *args, **kwargs: None,
+    },
+    type_checker=TypeChecker(),
+)
 
 
 # Properties this class might look for
```