### PR TITLE
Eliminate cache size limit

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cove: [ 'oc4ids' , 'ocds' , 'bods']
+        cove: [ 'oc4ids' , 'ocds' ]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
@@ -29,15 +29,6 @@ jobs:
         git checkout main
         cd ..
         git clone https://github.com/open-contracting/lib-cove-ocds.git
-
-    - name: bods
-      if: matrix.cove == 'bods'
-      run: |
-        git clone https://github.com/openownership/cove-bods.git
-        cd cove-bods
-        git checkout master
-        cd ..
-        git clone https://github.com/openownership/lib-cove-bods.git
 
     - name: Install
       run: |

--- a/libcove/lib/tools.py
+++ b/libcove/lib/tools.py
@@ -6,7 +6,7 @@ import requests
 from .exceptions import UnrecognisedFileType
 
 
-@lru_cache(maxsize=64)
+@lru_cache(maxsize=None)
 def cached_get_request(url):
     return requests.get(url)
 


### PR DESCRIPTION
64 is too small. When validating data using the OCDS for eForms profile, 141 requests need to be made, so they all get evicted in sequence and the cache serves no purpose.

There is no real downside to setting it to no limit. The responses to requests are small, and there is a limited universe of possible requests that will occur (there isn't an infinite number of extensions).

If you were concerned about a DOS attack from an agent that specifically targets CoVE with a crafted JSON text with millions of URLs – they can just as easily DOS with a single URL that retrieves a massive file.