### PR TITLE
Make flattentool dependency optional (aka add PyPy support for use cases not requiring flattentool)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cove: [ 'oc4ids' , 'ocds' , 'bods']
+        cove: [ 'oc4ids' , 'ocds' ]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
@@ -29,15 +29,6 @@ jobs:
         git checkout main
         cd ..
         git clone https://github.com/open-contracting/lib-cove-ocds.git
-
-    - name: bods
-      if: matrix.cove == 'bods'
-      run: |
-        git clone https://github.com/openownership/cove-bods.git
-        cd cove-bods
-        git checkout master
-        cd ..
-        git clone https://github.com/openownership/lib-cove-bods.git
 
     - name: Install
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,7 @@ jobs:
         pip install 'jsonref${{ matrix.jsonref-version }}'
     - name: Test
       run: py.test tests/
+    - name: Install with flatten requirement specifier
+      run: pip install .[flatten]
+    - name: Test with flatten requirement specifier
+      run: py.test tests/

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -21,7 +21,12 @@ try:
 except ImportError:
     from cached_property import cached_property
 
-from flattentool import unflatten
+# get_spreadsheet_meta_data() errors without the [flatten] requirement specifier.
+try:
+    from flattentool import unflatten
+except ImportError:
+    pass
+
 from jsonschema import FormatChecker, RefResolver
 from jsonschema._utils import ensure_list, extras_msg, find_additional_properties, uniq
 from jsonschema.exceptions import UndefinedTypeCheck, ValidationError

--- a/libcove/lib/converters.py
+++ b/libcove/lib/converters.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import warnings
 
+# libcove.lib.converters is unavailable without the [flatten] requirement specifier.
 import flattentool
 from flattentool.json_input import BadlyFormedJSONError
 

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,16 @@ setup(
         "jsonschema>=3",
         "requests",
         "cached-property;python_version<'3.8'",
-        "flattentool>=0.11.0",
         # Required for jsonschema to validate URIs
         "rfc3987",
         # Required for jsonschema to validate date-time
         "rfc3339-validator",
     ],
+    extras_require={
+        "flatten": [
+            "flattentool>=0.11.0",
+        ],
+    },
     classifiers=[
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)"
     ],

--- a/tests/lib/test_converters.py
+++ b/tests/lib/test_converters.py
@@ -3,8 +3,14 @@ import json
 import os
 import tempfile
 
+import pytest
+
 from libcove.config import LibCoveConfig
-from libcove.lib.converters import convert_json, convert_spreadsheet
+
+try:
+    from libcove.lib.converters import convert_json, convert_spreadsheet
+except ImportError:
+    pytestmark = pytest.mark.skip(reason="[flatten] requirement specifier not used")
 
 
 def test_convert_json_1():


### PR DESCRIPTION
Flatten tool has been getting more bloated (first in 0.15.3 then in 0.21.0).

Applications that don't require it can build and deploy faster without its many dependencies.

I now have 21 fewer indirect requirements (not including the direct and indirect ones introduced in 0.21.0).

The changelog entry I suggest is:

```md

### Changed

- libcove no longer installs flattentool by default. To install flattentool via libcove, set the `[flatten]' extra:

      pip install libcove[flatten]

  Without flattentool, calling `libcove.lib.common.get_spreadsheet_meta_data()` raises `NameError: name 'unflatten' is not defined`, and running `import libcove.lib.converters` raises `ModuleNotFoundError: No module named 'flattentool'`.
```