### PR TITLE
fix: Calculate additional codelist values for schema using anyOf, like OCDS record packages

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,12 +25,7 @@ jobs:
       if: matrix.cove == 'ocds'
       run: |
         git clone https://github.com/open-contracting/cove-ocds.git
-        cd cove-ocds
-        git checkout main
-        cd ..
         git clone https://github.com/open-contracting/lib-cove-ocds.git
-        cd lib-cove-ocds
-        git checkout 0.11.3
 
     - name: Install
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Calculate additional codelist values for schema using `anyOf`, like OCDS record packages https://github.com/open-contracting/lib-cove-ocds/issues/106
+
 ## [0.31.0] - 2023-07-06
 
 ### Changed

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -565,7 +565,7 @@ def custom_jsonref_jsonloader(schema_url, cache=None, **kwargs):
         uri_info = urlparse(uri)
         uri = urljoin(schema_url, os.path.basename(uri_info.path))
 
-        if "http" in uri_info.scheme:
+        if schema_url.startswith("http"):
             return get_request(uri, config=config).json(**kwargs)
         else:
             with open(uri) as schema_file:

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -492,17 +492,26 @@ def get_schema_codelist_paths(
         if "codelist" in value and path not in codelist_paths:
             codelist_paths[path] = (value["codelist"], value.get("openCodelist", False))
 
-        if value.get("type") == "object":
-            get_schema_codelist_paths(None, value, path, codelist_paths)
-        elif value.get("type") == "array" and isinstance(value.get("items"), dict):
-            if value.get("items").get("type") == "string":
-                if "codelist" in value["items"] and path not in codelist_paths:
-                    codelist_paths[path] = (
-                        value["items"]["codelist"],
-                        value["items"].get("openCodelist", False),
+        descendants = []
+        if "oneOf" in value and isinstance(value["oneOf"], list):
+            descendants = value["oneOf"]
+        else:
+            descendants = [value]
+
+        for value in descendants:
+            if value.get("type") == "object":
+                get_schema_codelist_paths(None, value, path, codelist_paths)
+            elif value.get("type") == "array" and isinstance(value.get("items"), dict):
+                if value.get("items").get("type") == "string":
+                    if "codelist" in value["items"] and path not in codelist_paths:
+                        codelist_paths[path] = (
+                            value["items"]["codelist"],
+                            value["items"].get("openCodelist", False),
+                        )
+                elif value.get("items").get("properties"):
+                    get_schema_codelist_paths(
+                        None, value["items"], path, codelist_paths
                     )
-            elif value.get("items").get("properties"):
-                get_schema_codelist_paths(None, value["items"], path, codelist_paths)
 
     return codelist_paths
 

--- a/tests/lib/test_common.py
+++ b/tests/lib/test_common.py
@@ -13,6 +13,7 @@ from libcove.lib.common import (
     _get_schema_deprecated_paths,
     add_field_coverage,
     add_field_coverage_percentages,
+    common_checks_context,
     fields_present_generator,
     get_additional_codelist_values,
     get_additional_fields_info,
@@ -26,6 +27,18 @@ from libcove.lib.common import (
     schema_dict_fields_generator,
     unique_ids,
 )
+
+
+def get_schema_obj(fixture):
+    schema_obj = SchemaJsonMixin()
+    schema_obj.schema_host = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "fixtures", "common/"
+    )
+    schema_obj.release_pkg_schema_name = f"{fixture}.json"
+    schema_obj.pkg_schema_url = os.path.join(
+        schema_obj.schema_host, schema_obj.release_pkg_schema_name
+    )
+    return schema_obj
 
 
 def test_unique_ids_False():
@@ -1345,5 +1358,34 @@ def test_get_additional_codelist_values():
             "isopen": False,
             "values": ["AAA"],
             "extension_codelist": False,
+        },
+    }
+
+
+def test_get_additional_codelist_values_anyOf():
+    json_data = {
+        "version": "1.1",
+        "records": [
+            {
+                "releases": [
+                    {"parties": [{"id": "1", "name": "Name", "roles": ["additional"]}]}
+                ]
+            }
+        ],
+    }
+    schema_obj = get_schema_obj("record-package-schema")
+    schema_obj.codelists = "https://raw.githubusercontent.com/open-contracting/standard/1.1/schema/codelists/"
+    additional_codelist_values = get_additional_codelist_values(schema_obj, json_data)
+
+    assert additional_codelist_values == {
+        "records/releases/parties/roles": {
+            "codelist": "partyRole.csv",
+            "codelist_amend_urls": [],
+            "codelist_url": "https://raw.githubusercontent.com/open-contracting/standard/1.1/schema/codelists/partyRole.csv",
+            "extension_codelist": False,
+            "field": "roles",
+            "isopen": True,
+            "path": "records/releases/parties",
+            "values": ["additional"],
         },
     }


### PR DESCRIPTION
open-contracting/lib-cove-ocds#106

Diff is smaller if ignoring whitespace: https://github.com/OpenDataServices/lib-cove/pull/125/files?w=1