### PR TITLE
Allow SchemaJsonMixin classes to define a validator method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Allow `SchemaJsonMixin` classes to define a `validator` method, that accepts lib-cove's JSON Schema draft 4 validator class and its format checker, and returns a validator instance.
+
 ## [0.31.0] - 2023-07-06
 
 ### Changed


### PR DESCRIPTION
This method accepts lib-cove's JSON Schema draft 4 validator class and its format checker, and returns a validator instance.

----

This along with https://github.com/OpenDataServices/lib-cove/pull/129 is an easier-to-merge alternative to #123. It will give lib-cove-ocds the flexibility it needs to (1) use the latest jsonschema and (2) not see deprecation warnings.