### PR TITLE
Drop support for Python 3.6 and jsonschema 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
         # We also only use Linux servers, so don't test on Mac
         # Need to use an older Ubuntu so Python 3.6 is available
         os: [ubuntu-20.04]
-        python-version: [ 3.6, 3.7, 3.8, 3.9, "3.10", "3.11" ]
+        python-version: [ 3.7, 3.8, 3.9, "3.10", "3.11" ]
         jsonref-version: ["==0.3", ">1"]
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Drop Python 3.6 support
+- Drop jsonschema 3 support
+
 ## [0.31.0] - 2023-07-06
 
 ### Changed

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -235,7 +235,9 @@ def oneOf_draft4(validator, oneOf, instance, schema):
                 context=all_errors,
             )
 
-    more_valid = [s for i, s in subschemas if validator.is_valid(instance, s)]
+    more_valid = [
+        s for i, s in subschemas if validator.evolve(schema=s).is_valid(instance)
+    ]
     if more_valid:
         more_valid.append(first_valid)
         reprs = ", ".join(repr(schema) for schema in more_valid)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     long_description="A data review library",
     install_requires=[
         "jsonref",
-        "jsonschema>=3",
+        "jsonschema>=4",
         "requests",
         "cached-property;python_version<'3.8'",
         "flattentool>=0.11.0",


### PR DESCRIPTION
This along with https://github.com/OpenDataServices/lib-cove/pull/128 is an easier-to-merge alternative to #123. It will give lib-cove-ocds the flexibility it needs to (1) use the latest jsonschema and (2) not see deprecation warnings.