### PR TITLE
Descend into nullable objects and arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Calculate additional codelist values for schema using `anyOf` or `oneOf`, like OCDS record packages https://github.com/open-contracting/lib-cove-ocds/issues/106
+- Descend into nullable objects and arrays. (For example, OCDS `parties/details` is nullable, and additional codes for `parties/details/scale` were unreported.) https://github.com/OpenDataServices/lib-cove/pull/131
 
 ## [0.31.0] - 2023-07-06
 

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -430,6 +430,13 @@ def schema_dict_fields_generator(schema_dict):
                     yield field
 
 
+def _get_types(value: dict):
+    types = value.get("type", [])
+    if not isinstance(types, list):
+        return [types]
+    return types
+
+
 def get_schema_codelist_paths(
     schema_obj, obj=None, current_path=(), codelist_paths=None, use_extensions=False
 ):
@@ -465,10 +472,11 @@ def get_schema_codelist_paths(
             descendants = [value]
 
         for value in descendants:
-            if value.get("type") == "object":
+            types = _get_types(value)
+            if "object" in types:
                 get_schema_codelist_paths(None, value, path, codelist_paths)
-            elif value.get("type") == "array" and isinstance(value.get("items"), dict):
-                if value.get("items").get("type") == "string":
+            elif "array" in types and isinstance(value.get("items"), dict):
+                if "string" in _get_types(value["items"]):
                     if "codelist" in value["items"] and path not in codelist_paths:
                         codelist_paths[path] = (
                             value["items"]["codelist"],
@@ -1258,10 +1266,11 @@ def _get_schema_deprecated_paths(
                     )
                 )
 
-        if value.get("type") == "object":
+        types = _get_types(value)
+        if "object" in types:
             _get_schema_deprecated_paths(None, value, path, deprecated_paths)
         elif (
-            value.get("type") == "array"
+            "array" in types
             and isinstance(value.get("items"), dict)
             and value.get("items").get("properties")
         ):
@@ -1303,10 +1312,11 @@ def _get_schema_non_required_ids(
         if prop == "id" and no_required_id and array_parent and not list_merge:
             id_paths.append(path)
 
-        if value.get("type") == "object":
+        types = _get_types(value)
+        if "object" in types:
             _get_schema_non_required_ids(None, value, path, id_paths)
         elif (
-            value.get("type") == "array"
+            "array" in types
             and isinstance(value.get("items"), dict)
             and value.get("items").get("properties")
         ):
@@ -1350,16 +1360,18 @@ def add_is_codelist(obj):
             )
             continue
 
+        types = _get_types(value)
+
         if "codelist" in value:
-            if "array" in value.get("type", ""):
+            if "array" in types:
                 value["items"]["isCodelist"] = True
             else:
                 value["isCodelist"] = True
 
-        if value.get("type") == "object":
+        if "object" in types:
             add_is_codelist(value)
         elif (
-            value.get("type") == "array"
+            "array" in types
             and isinstance(value.get("items"), dict)
             and value.get("items").get("properties")
         ):

--- a/tests/lib/fixtures/common/schema_nullable_object_and_array.json
+++ b/tests/lib/fixtures/common/schema_nullable_object_and_array.json
@@ -1,0 +1,39 @@
+{
+    "properties": {
+        "array": {
+            "type": ["array", "null"],
+            "items": {
+                "$ref": "#/definitions/Object"
+            }
+        },
+        "object": {
+            "$ref": "#/definitions/Object"
+        }
+    },
+    "definitions": {
+        "Object": {
+            "type": ["object", "null"],
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "scale": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "small",
+                            "large"
+                        ]
+                    },
+                    "codelist": "partyScale.csv",
+                    "openCodelist": false,
+                    "deprecated": {
+                        "deprecatedVersion": "1.1",
+                        "description": ""
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
For example, OCDS `parties/details` is nullable, and additional codes for `parties/details/scale` were unreported.

https://github.com/OpenDataServices/lib-cove/pull/131