### PR TITLE
fix: unique_ids has exponential running time if no ID fields

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,17 +17,10 @@ jobs:
       run: |
         sudo apt-get install gettext translate-toolkit
 
-    - name: oc4ids
-      if: matrix.cove == 'oc4ids'
+    - name: Clone
       run: |
-        git clone https://github.com/open-contracting/cove-oc4ids.git
-        git clone https://github.com/open-contracting/lib-cove-oc4ids.git
-
-    - name: ocds
-      if: matrix.cove == 'ocds'
-      run: |
-        git clone https://github.com/open-contracting/cove-ocds.git
-        git clone https://github.com/open-contracting/lib-cove-ocds.git
+        git clone https://github.com/open-contracting/cove-${{ matrix.cove }}.git
+        git clone https://github.com/open-contracting/lib-cove-${{ matrix.cove }}.git
 
     - name: Install
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,13 +52,6 @@ jobs:
         cd cove-${{ matrix.cove }}
         DJANGO_SETTINGS_MODULE=cove_project.settings py.test
 
-    - name: lib-cove-ocds requirements
-      if: matrix.cove == 'ocds'
-      run: |
-        # Upgrade Django for lib-cove-ocds tests, as they rely on some details
-        # of entity quoting that have changed
-        pip install --upgrade Django
-
     - name: Test cove lib instance
       run: |
         cd lib-cove-${{ matrix.cove }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,10 +7,12 @@ jobs:
       matrix:
         cove: [ 'oc4ids' , 'ocds' ]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: '3.10'
+        cache: pip
+        cache-dependency-path: '**/requirements*.txt'
     - name: InstallCommon
       run: |
         sudo apt-get install gettext translate-toolkit
@@ -29,13 +31,12 @@ jobs:
 
     - name: Install
       run: |
-        pip install -r cove-${{ matrix.cove }}/requirements.txt
-        pip install -r cove-${{ matrix.cove }}/requirements_dev.txt
         pip install -r requirements_dev.txt
+        pip install -r cove-${{ matrix.cove }}/requirements_dev.txt
         # Make sure we're using local libs rather than one brought in
         # via requirements.
-        pip install -e .
         pip install -e ./lib-cove-${{ matrix.cove }}/
+        pip install -e .
         pip list
 
     - name: Compile Messages

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -89,7 +89,7 @@ def unique_ids(validator, ui, instance, schema, id_names=["id"]):
     if ui and validator.is_type(instance, "array"):
         non_unique_ids = set()
         all_ids = set()
-        run_uniq = False
+        uniq_has_run = False
 
         for item in instance:
             try:
@@ -104,15 +104,14 @@ def unique_ids(validator, ui, instance, schema, id_names=["id"]):
                 if item_ids in all_ids:
                     non_unique_ids.add(item_ids)
                 all_ids.add(item_ids)
-            else:
-                run_uniq = True
-
-        if run_uniq and not uniq(instance):
-            msg = "Array has non-unique elements"
-            err = ValidationError(msg, instance=instance)
-            err.error_id = "uniqueItems_no_ids"
-            yield err
-            return
+            elif not uniq_has_run:
+                if not uniq(instance):
+                    msg = "Array has non-unique elements"
+                    err = ValidationError(msg, instance=instance)
+                    err.error_id = "uniqueItems_no_ids"
+                    yield err
+                    return
+                uniq_has_run = True
 
         for non_unique_id in sorted(non_unique_ids):
             if len(id_names) == 1:

--- a/libcove/lib/common.py
+++ b/libcove/lib/common.py
@@ -89,6 +89,8 @@ def unique_ids(validator, ui, instance, schema, id_names=["id"]):
     if ui and validator.is_type(instance, "array"):
         non_unique_ids = set()
         all_ids = set()
+        run_uniq = False
+
         for item in instance:
             try:
                 item_ids = tuple(item.get(id_name) for id_name in id_names)
@@ -96,21 +98,21 @@ def unique_ids(validator, ui, instance, schema, id_names=["id"]):
                 # if item is not a dict
                 item_ids = None
             if item_ids and all(
-                item_id is not None
-                and not isinstance(item_id, list)
-                and not isinstance(item_id, dict)
+                item_id is not None and not isinstance(item_id, (dict, list))
                 for item_id in item_ids
             ):
                 if item_ids in all_ids:
                     non_unique_ids.add(item_ids)
                 all_ids.add(item_ids)
             else:
-                if not uniq(instance):
-                    msg = "Array has non-unique elements"
-                    err = ValidationError(msg, instance=instance)
-                    err.error_id = "uniqueItems_no_ids"
-                    yield err
-                    return
+                run_uniq = True
+
+        if run_uniq and not uniq(instance):
+            msg = "Array has non-unique elements"
+            err = ValidationError(msg, instance=instance)
+            err.error_id = "uniqueItems_no_ids"
+            yield err
+            return
 
         for non_unique_id in sorted(non_unique_ids):
             if len(id_names) == 1:


### PR DESCRIPTION
If `instance` has no ID fields, `uniq(instance)` isn't called once, but as many times as the length of `instance`.

Original commit d28dd0129690df972c46a917c13e2f94764f5225